### PR TITLE
Do not check for user rights when the task pages are created from the task macro listener #19

### DIFF
--- a/application-task-default/pom.xml
+++ b/application-task-default/pom.xml
@@ -119,4 +119,23 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <!-- Apply the Checkstyle configurations defined in the top level pom.xml file -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Specify the "default" execution id so that the "blocker" one is always executed -->
+            <id>default</id>
+            <configuration>
+              <failsOnError>true</failsOnError>
+              <suppressionsLocation>${basedir}/src/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/application-task-default/src/checkstyle/checkstyle-suppressions.xml
+++ b/application-task-default/src/checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<!DOCTYPE suppressions PUBLIC
+  "-//Puppy Crawl//DTD Suppressions 1.0//EN"
+  "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+
+<suppressions>
+  <suppress checks="ClassFanOutComplexity"
+    files="src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener\.java"/>
+</suppressions>

--- a/application-task-default/src/main/java/com/xwiki/task/internal/DefaultTaskReferenceGenerator.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/DefaultTaskReferenceGenerator.java
@@ -29,10 +29,7 @@ import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.SpaceReference;
-import org.xwiki.security.authorization.ContextualAuthorizationManager;
-import org.xwiki.security.authorization.Right;
 
-import com.xwiki.task.TaskException;
 import com.xwiki.task.TaskReferenceGenerator;
 
 /**
@@ -47,29 +44,16 @@ public class DefaultTaskReferenceGenerator implements TaskReferenceGenerator
 {
     private static final String TASK_PAGE_NAME_PREFIX = "Task_";
 
-    private static final String TASK_MANAGER_SPACE = "TaskManager";
-
-    @Inject
-    private ContextualAuthorizationManager authorizationManager;
-
     @Inject
     private DocumentAccessBridge documentAccessBridge;
 
     private final Map<SpaceReference, Integer> nameOccurences = new HashMap<>();
 
     @Override
-    public synchronized DocumentReference generate(DocumentReference parent) throws TaskException
+    public synchronized DocumentReference generate(DocumentReference parent)
     {
 
         SpaceReference parentSpaceRef = parent.getLastSpaceReference();
-        if (!authorizationManager.hasAccess(Right.EDIT, parentSpaceRef)) {
-            parentSpaceRef = new SpaceReference(parent.getWikiReference().getName(), TASK_MANAGER_SPACE);
-            if (!authorizationManager.hasAccess(Right.EDIT, parentSpaceRef)) {
-                throw new TaskException(String.format(
-                    "The current user does not have rights over [%s] or [%s] thus the task page could not be created.",
-                    parent.getLastSpaceReference(), parentSpaceRef));
-            }
-        }
         return getUniqueName(parentSpaceRef);
     }
 

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
@@ -23,6 +23,7 @@ package com.xwiki.task.internal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -208,7 +209,8 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
             DocumentReference taskReference = task.getReference();
             try {
                 if (!isChildOf(taskReference, document.getDocumentReference())
-                    && !authorizationManager.hasAccess(Right.EDIT, taskReference)) {
+                    && !authorizationManager.hasAccess(Right.EDIT, taskReference))
+                {
                     logger.warn(
                         "The user [{}] edited the macro with id [{}] but does not have edit rights over it's "
                             + "corresponding page.",
@@ -243,11 +245,12 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
     {
         String webHome = referenceProvider.getDefaultReference(EntityType.DOCUMENT).getName();
         if (!possibleParent.getName().equals(webHome)) {
+            // Terminal pages can't have child pages.
             return false;
         }
-        EntityReference childParent = possibleChild.getName().equals(webHome)  && possibleChild.getParent() != null
-            ? possibleChild.getParent().getParent() : possibleChild.getParent();
-        return childParent != null && childParent.equals(possibleParent.getLastSpaceReference());
+        EntityReference childParent =
+            possibleChild.getName().equals(webHome) ? possibleChild.getParent().getParent() : possibleChild.getParent();
+        return Objects.equals(childParent, possibleParent.getLastSpaceReference());
     }
 
     private void populateObjectWithMacroParams(XWikiContext context, Task task, BaseObject object)

--- a/application-task-default/src/test/java/com/xwiki/task/DefaultTaskReferenceGeneratorTest.java
+++ b/application-task-default/src/test/java/com/xwiki/task/DefaultTaskReferenceGeneratorTest.java
@@ -26,9 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.model.reference.SpaceReference;
-import org.xwiki.security.authorization.ContextualAuthorizationManager;
-import org.xwiki.security.authorization.Right;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
@@ -46,9 +43,6 @@ class DefaultTaskReferenceGeneratorTest
 {
     @InjectMockComponents
     private DefaultTaskReferenceGenerator referenceGenerator;
-
-    @MockComponent
-    private ContextualAuthorizationManager authorizationManager;
 
     @MockComponent
     private Provider<XWikiContext> contextProvider;
@@ -72,8 +66,6 @@ class DefaultTaskReferenceGeneratorTest
         when(this.contextProvider.get()).thenReturn(this.context);
         when(this.context.getUserReference()).thenReturn(this.userReference);
         when(this.context.getWiki()).thenReturn(this.wiki);
-        when(this.authorizationManager.hasAccess(Right.EDIT, this.documentReference.getLastSpaceReference()))
-            .thenReturn(true);
     }
 
     @Test
@@ -99,21 +91,6 @@ class DefaultTaskReferenceGeneratorTest
         DocumentReference generatedReference = this.referenceGenerator.generate(documentReference);
 
         assertEquals(new DocumentReference("Task_1", documentReference.getLastSpaceReference()),
-            generatedReference);
-    }
-
-    @Test
-    void generateReferenceWhenTheUserDoesNotHaveEditRightsOnTheSpace() throws TaskException
-    {
-        when(this.documentAccessBridge.exists(any(DocumentReference.class))).thenReturn(false);
-        when(this.authorizationManager.hasAccess(Right.EDIT, this.documentReference.getLastSpaceReference()))
-            .thenReturn(false);
-        when(this.authorizationManager.hasAccess(Right.EDIT, new SpaceReference("xwiki", "TaskManager")))
-            .thenReturn(true);
-
-        DocumentReference generatedReference = this.referenceGenerator.generate(documentReference);
-
-        assertEquals(new DocumentReference("xwiki", "TaskManager", "Task_0"),
             generatedReference);
     }
 }

--- a/application-task-default/src/test/java/com/xwiki/task/TaskMacroUpdateEventListenerTest.java
+++ b/application-task-default/src/test/java/com/xwiki/task/TaskMacroUpdateEventListenerTest.java
@@ -31,8 +31,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.xwiki.bridge.event.DocumentDeletingEvent;
 import org.xwiki.bridge.event.DocumentUpdatingEvent;
+import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReferenceProvider;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.XDOM;
@@ -87,6 +89,9 @@ class TaskMacroUpdateEventListenerTest
     @MockComponent
     private DocumentReferenceResolver<String> resolver;
 
+    @MockComponent
+    private EntityReferenceProvider referenceProvider;
+
     @Mock
     private XWikiContext context;
 
@@ -137,6 +142,8 @@ class TaskMacroUpdateEventListenerTest
     @BeforeEach
     void setup() throws XWikiException
     {
+        when(this.referenceProvider.getDefaultReference(EntityType.DOCUMENT)).thenReturn(new DocumentReference(
+            "xwiki", "XWiki", "WebHome"));
         when(this.context.getWiki()).thenReturn(this.wiki);
         when(this.docWithTasks.getDocumentReference()).thenReturn(this.pageWithMacro);
         when(this.docWithTasks.getXDOM()).thenReturn(this.docXDOM);


### PR DESCRIPTION
Solved the issue by allowing the listener to create a page without checking rights only when that page is a child of the currently edited page.