### PR TITLE
Task name isn't displayed in tab during creation neither in breadcumb…

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
@@ -31,7 +31,7 @@
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
   <version>1.1</version>
-  <title>$!{doc.getObject('TaskManager.TaskManagerClass').getProperty('name').value}</title>
+  <title>#set($name = $!{doc.getObject('TaskManager.TaskManagerClass').getProperty('name').value})#if("$!name" != '')$name#elseif("$!request.title"!='')$request.title#elseif($doc.documentReference.name != 'WebHome')$doc.documentReference.name#else$doc.documentReference.parent.name#end</title>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>


### PR DESCRIPTION
…s menu #37

* Some titles of extension pages aren't displayed in web-browser tab, as page compenent and in breadcumb menu #42