### PR TITLE
Adding a task and saving the document multiple times will assign an I…

### DIFF
--- a/application-task-api/src/main/java/com/xwiki/task/macro/TaskMacroParameters.java
+++ b/application-task-api/src/main/java/com/xwiki/task/macro/TaskMacroParameters.java
@@ -22,6 +22,7 @@ package com.xwiki.task.macro;
 
 import org.xwiki.properties.annotation.PropertyDisplayHidden;
 import org.xwiki.properties.annotation.PropertyDisplayType;
+import org.xwiki.properties.annotation.PropertyMandatory;
 import org.xwiki.stability.Unstable;
 
 import com.xwiki.task.TaskDate;
@@ -56,7 +57,7 @@ public class TaskMacroParameters
     /**
      * @param reference the id of the task.
      */
-    @PropertyDisplayHidden
+    @PropertyMandatory
     @PropertyDisplayType(TaskReference.class)
     public void setReference(String reference)
     {

--- a/application-task-api/src/main/java/com/xwiki/task/rest/TaskIdResource.java
+++ b/application-task-api/src/main/java/com/xwiki/task/rest/TaskIdResource.java
@@ -1,5 +1,3 @@
-package com.xwiki.task.rest;
-
 /*
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,46 +17,40 @@ package com.xwiki.task.rest;
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+package com.xwiki.task.rest;
 
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Encoded;
-import javax.ws.rs.PUT;
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Response;
 
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.stability.Unstable;
 
-import com.xwiki.task.model.Task;
-
 /**
- * Provides operations on task pages.
+ * Provides operations on the task macros of a page.
  *
  * @version $Id$
- * @since 3.0
+ * @since 3.1
  */
-@Path("/wikis/{wikiName}/spaces/{spaceName: .+}/pages/{pageName}/task")
+@Path("/wikis/{wikiName}/spaces/{spaceName: .+}/pages/{pageName}/tasks/generate-reference")
 @Unstable
-public interface TaskResource
+public interface TaskIdResource
 {
     /**
-     * Modify the status of a Task macro.
+     * Generate an id for a task macro residing in a given page.
      *
      * @param wikiName the name of the wiki in which the page resides
      * @param spaces the spaces of the page
      * @param pageName the name of the page
-     * @param status whether the task has been completed or not
-     * @return 200 is the status has been changed successfully of 404 if the task was not found
-     * @throws XWikiRestException when failing in retrieving the document or saving it
+     * @return 200 and a serialized, unused reference of a task. The reference will either be a child or sibling to the
+     *     given page, depending on the user rights.
+     * @throws XWikiRestException if the generation of the reference fails. Error code 500.
      */
-    // TODO: Replace with a generic method that can be used to modify any value of the task.
-    @PUT
-    Response changeTaskStatus(
+    @GET
+    String generateId(
         @PathParam("wikiName") String wikiName,
         @PathParam("spaceName") @Encoded String spaces,
-        @PathParam("pageName") String pageName,
-        @QueryParam("status") @DefaultValue(Task.STATUS_DONE) String status
+        @PathParam("pageName") String pageName
     ) throws XWikiRestException;
 }

--- a/application-task-api/src/main/java/com/xwiki/task/rest/TaskReferenceResource.java
+++ b/application-task-api/src/main/java/com/xwiki/task/rest/TaskReferenceResource.java
@@ -28,14 +28,14 @@ import org.xwiki.rest.XWikiRestException;
 import org.xwiki.stability.Unstable;
 
 /**
- * Provides operations on the task macros of a page.
+ * Provides a way to generate task references.
  *
  * @version $Id$
  * @since 3.1
  */
-@Path("/wikis/{wikiName}/spaces/{spaceName: .+}/pages/{pageName}/tasks/generate-reference")
+@Path("/wikis/{wikiName}/spaces/{spaceName: .+}/pages/{pageName}/task-reference")
 @Unstable
-public interface TaskIdResource
+public interface TaskReferenceResource
 {
     /**
      * Generate an id for a task macro residing in a given page.

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
@@ -143,14 +143,7 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
                     ExceptionUtils.getRootCauseMessage(e));
             }
         }
-        if (tasks.size() > 0 || previousDocTasks.size() > 0) {
-            // TaskExtractor will add new IDs to the tasks if they don't have one, so we need to update the content.
-            try {
-                document.setContent(documentContent);
-            } catch (XWikiException e) {
-                logger.warn("Could not update the content of the document [{}]: [{}].",
-                    document.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
-            }
+        if (!tasks.isEmpty() || !previousDocTasks.isEmpty()) {
             context.put(TASK_UPDATE_FLAG, true);
             deleteTaskPages(document, context, previousDocTasks);
             createOrUpdateTaskPages(document, context, tasks);

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
@@ -173,7 +173,6 @@ public class TaskXDOMProcessor
             return null;
         }
         task.setReference(resolver.resolve(macroId, contentSource));
-        task.setOwner(contentSource);
         extractBasicProperties(macroParams, task);
 
         try {

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
@@ -166,13 +167,13 @@ public class TaskXDOMProcessor
     private Task initTask(Syntax syntax, DocumentReference contentSource, MacroBlock macro)
     {
         Map<String, String> macroParams = macro.getParameters();
-        String macroId = macroParams.get(Task.REFERENCE);
+        String taskReference = macroParams.get(Task.REFERENCE);
         Task task = new Task();
 
-        if (macroId == null || macroId.isEmpty()) {
+        if (StringUtils.isEmpty(taskReference)) {
             return null;
         }
-        task.setReference(resolver.resolve(macroId, contentSource));
+        task.setReference(resolver.resolve(taskReference, contentSource));
         extractBasicProperties(macroParams, task);
 
         try {

--- a/application-task-default/src/main/java/com/xwiki/task/internal/rest/DefaultTaskIdResource.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/rest/DefaultTaskIdResource.java
@@ -1,0 +1,74 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.task.internal.rest;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.rest.XWikiResource;
+import org.xwiki.rest.XWikiRestException;
+import org.xwiki.security.authorization.ContextualAuthorizationManager;
+import org.xwiki.security.authorization.Right;
+
+import com.xwiki.task.TaskException;
+import com.xwiki.task.TaskReferenceGenerator;
+import com.xwiki.task.rest.TaskIdResource;
+
+/**
+ * Default implementation of {@link TaskIdResource}.
+ *
+ * @version $Id$
+ * @since 3.1
+ */
+@Component
+@Named("com.xwiki.task.internal.rest.DefaultTaskIdResource")
+@Singleton
+public class DefaultTaskIdResource extends XWikiResource implements TaskIdResource
+{
+    @Inject
+    private ContextualAuthorizationManager contextualAuthorizationManager;
+
+    @Inject
+    private TaskReferenceGenerator taskReferenceGenerator;
+
+    @Inject
+    @Named("compact")
+    private EntityReferenceSerializer<String> serializer;
+
+    @Override
+    public String generateId(String wikiName, String spaces, String pageName) throws XWikiRestException
+    {
+        DocumentReference docRef = new DocumentReference(pageName, getSpaceReference(spaces, wikiName));
+        if (!contextualAuthorizationManager.hasAccess(Right.EDIT, docRef)) {
+            throw new WebApplicationException(Response.Status.FORBIDDEN);
+        }
+        try {
+            return serializer.serialize(taskReferenceGenerator.generate(docRef));
+        } catch (TaskException e) {
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/application-task-default/src/main/java/com/xwiki/task/internal/rest/DefaultTaskReferenceResource.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/rest/DefaultTaskReferenceResource.java
@@ -35,18 +35,18 @@ import org.xwiki.security.authorization.Right;
 
 import com.xwiki.task.TaskException;
 import com.xwiki.task.TaskReferenceGenerator;
-import com.xwiki.task.rest.TaskIdResource;
+import com.xwiki.task.rest.TaskReferenceResource;
 
 /**
- * Default implementation of {@link TaskIdResource}.
+ * Default implementation of {@link TaskReferenceResource}.
  *
  * @version $Id$
  * @since 3.1
  */
 @Component
-@Named("com.xwiki.task.internal.rest.DefaultTaskIdResource")
+@Named("com.xwiki.task.internal.rest.DefaultTaskReferenceResource")
 @Singleton
-public class DefaultTaskIdResource extends XWikiResource implements TaskIdResource
+public class DefaultTaskReferenceResource extends XWikiResource implements TaskReferenceResource
 {
     @Inject
     private ContextualAuthorizationManager contextualAuthorizationManager;

--- a/application-task-default/src/main/resources/META-INF/components.txt
+++ b/application-task-default/src/main/resources/META-INF/components.txt
@@ -16,5 +16,5 @@ com.xwiki.task.internal.TaskObjectUpdateEventListener
 com.xwiki.task.internal.macro.TaskMacro
 com.xwiki.task.internal.macro.TasksMacro
 com.xwiki.task.internal.macro.DateMacro
-com.xwiki.task.internal.rest.DefaultTaskIdResource
+com.xwiki.task.internal.rest.DefaultTaskReferenceResource
 com.xwiki.task.internal.rest.DefaultTaskResource

--- a/application-task-default/src/main/resources/META-INF/components.txt
+++ b/application-task-default/src/main/resources/META-INF/components.txt
@@ -16,4 +16,5 @@ com.xwiki.task.internal.TaskObjectUpdateEventListener
 com.xwiki.task.internal.macro.TaskMacro
 com.xwiki.task.internal.macro.TasksMacro
 com.xwiki.task.internal.macro.DateMacro
+com.xwiki.task.internal.rest.DefaultTaskIdResource
 com.xwiki.task.internal.rest.DefaultTaskResource

--- a/application-task-default/src/test/java/com/xwiki/task/TaskXDOMProcessorTest.java
+++ b/application-task-default/src/test/java/com/xwiki/task/TaskXDOMProcessorTest.java
@@ -178,14 +178,7 @@ public class TaskXDOMProcessorTest
 
         callVisitorLambdaFunction();
 
-        verify(this.taskReferenceGenerator).generate(this.contentSource);
-        verify(this.taskMacro1).setParameter(Task.REFERENCE, this.task1Reference.toString());
-
-        assertEquals(1, result.size());
-        Task task = result.get(0);
-        assertEquals("TaskContent", task.getName());
-        assertEquals(this.task1Reference, task.getReference());
-        assertEquals(this.contentSource, task.getOwner());
+        assertEquals(0, result.size());
     }
 
     @Test

--- a/application-task-ui/src/main/resources/TaskManager/TaskMacroInit.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskMacroInit.xml
@@ -160,7 +160,8 @@ require(['moment-setup'], function () {
         let refGenURL = XWiki.currentDocument.getRestURL() + '/task-reference';
         idInput.prop('disabled', true);
         idInput.addClass('loading');
-        let not = new XWiki.widgets.Notification(l10n.get('referenceGeneration.inprogress'), 'inprogress')
+        modal.find('.btn-primary').prop('disabled', true);
+        let not = new XWiki.widgets.Notification(l10n.get('referenceGeneration.inprogress'), 'inprogress');
         $.ajax({
           url: refGenURL,
           method: 'GET',
@@ -176,6 +177,7 @@ require(['moment-setup'], function () {
           .always(function () {
             idInput.prop('disabled', false);
             idInput.removeClass('loading');
+            modal.find('.btn-primary').prop('disabled', false);
           });
         let createDateInput = modal.find("input[name='createDate']");
         let creatorInput = modal.find("input[name='reporter']");

--- a/application-task-ui/src/main/resources/TaskManager/TaskMacroInit.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskMacroInit.xml
@@ -130,8 +130,14 @@
     'moment-jdateformatparser': "$services.webjars.url('moment-jdateformatparser', 'moment-jdateformatparser.min')"
   }
 });
+define('task-modal', {
+  prefix: 'taskmanager.notification.referenceGeneration.',
+  keys: [
+    'fail'
+  ]
+});
 require(['moment-setup'], function () {
-  require(['jquery', 'xwiki-meta', 'moment', 'moment-jdateformatparser'], function ($, xm, moment) {
+  require(['jquery', 'xwiki-l10n!task-modal', 'xwiki-meta', 'moment', 'moment-jdateformatparser'], function ($, l10n, xm, moment) {
     let initCompleteDate = function () {
       // TODO: Replace 'Done' with an user configurable value.
       if ($(this).val() == 'Done') {
@@ -150,6 +156,24 @@ require(['moment-setup'], function () {
         let idInput = modal.find("input[name='reference']");
         $('.modal select[name="status"]').each(initCompleteDate)
         if (idInput.val()) return;
+        let refGenURL = XWiki.currentDocument.getRestURL() + '/tasks/generate-reference';
+        idInput.prop('disabled', true);
+        idInput.addClass('loading');
+        $.ajax({
+          url: refGenURL,
+          method: 'GET',
+          dataType: 'text'
+        })
+          .done(function (ref) {
+            idInput.val(ref);
+          })
+          .fail(function (response) {
+            new XWiki.widgets.Notification(l10n.fail, 'error');
+          })
+          .always(function () {
+            idInput.prop('disabled', false);
+            idInput.removeClass('loading');
+          });
         let createDateInput = modal.find("input[name='createDate']");
         let creatorInput = modal.find("input[name='reporter']");
         var dateFormat = moment().toMomentFormatString($(idInput).data('dateformat'));

--- a/application-task-ui/src/main/resources/TaskManager/TaskMacroInit.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskMacroInit.xml
@@ -130,14 +130,15 @@
     'moment-jdateformatparser': "$services.webjars.url('moment-jdateformatparser', 'moment-jdateformatparser.min')"
   }
 });
-define('task-modal', {
-  prefix: 'taskmanager.notification.referenceGeneration.',
+define('xwiki-task-notification-messages', {
+  prefix: 'taskmanager.notification.',
   keys: [
-    'fail'
+    'referenceGeneration.fail',
+    'referenceGeneration.inprogress'
   ]
 });
 require(['moment-setup'], function () {
-  require(['jquery', 'xwiki-l10n!task-modal', 'xwiki-meta', 'moment', 'moment-jdateformatparser'], function ($, l10n, xm, moment) {
+  require(['jquery', 'xwiki-l10n!xwiki-task-notification-messages', 'xwiki-meta', 'moment', 'moment-jdateformatparser'], function ($, l10n, xm, moment) {
     let initCompleteDate = function () {
       // TODO: Replace 'Done' with an user configurable value.
       if ($(this).val() == 'Done') {
@@ -156,19 +157,21 @@ require(['moment-setup'], function () {
         let idInput = modal.find("input[name='reference']");
         $('.modal select[name="status"]').each(initCompleteDate)
         if (idInput.val()) return;
-        let refGenURL = XWiki.currentDocument.getRestURL() + '/tasks/generate-reference';
+        let refGenURL = XWiki.currentDocument.getRestURL() + '/task-reference';
         idInput.prop('disabled', true);
         idInput.addClass('loading');
+        let not = new XWiki.widgets.Notification(l10n.get('referenceGeneration.inprogress'), 'inprogress')
         $.ajax({
           url: refGenURL,
           method: 'GET',
           dataType: 'text'
         })
           .done(function (ref) {
+            not.hide();
             idInput.val(ref);
           })
           .fail(function (response) {
-            new XWiki.widgets.Notification(l10n.fail, 'error');
+            not.replace(new XWiki.widgets.Notification(l10n.get('referenceGeneration.fail'), 'error'));
           })
           .always(function () {
             idInput.prop('disabled', false);

--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerTranslations.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerTranslations.xml
@@ -146,6 +146,8 @@ taskmanager.notification.statusChange.success=Task status changed successfully!
 taskmanager.notification.statusChange.restFail=Failed to change the status because of a server error!
 taskmanager.notification.statusChange.noId=Failed to change the status because the task doesn't have an ID.
 taskmanager.notification.statusChange.inprogress=Changing status..
+taskmanager.notification.referenceGeneration.fail=Failed to generate a task reference
+taskmanager.notification.referenceGeneration.inprogress=Generating task reference
 
 taskmanager.livetable.name=Task
 taskmanager.livetable.duedate=Deadline


### PR DESCRIPTION
…D greater than it should #33

Made the reference parameter of the task macro mandatory.
Added some JS code and an endpoint with the purpose of generating task references.
Removed the backend generation of references after the DocumentSaved event.