### PR TITLE
Scalability issues when deleting pages with multiple tasks #72

### DIFF
--- a/application-task-default/src/main/java/com/xwiki/task/internal/AbstractTaskEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/AbstractTaskEventListener.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
+import org.xwiki.job.JobExecutor;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.observation.AbstractEventListener;
@@ -65,6 +66,9 @@ public abstract class AbstractTaskEventListener extends AbstractEventListener
 
     @Inject
     protected Logger logger;
+
+    @Inject
+    protected JobExecutor executor;
 
     @Inject
     private ObservationContext observationContext;

--- a/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
+++ b/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
@@ -45,7 +45,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @version $Id$
  * @since 2.6
  */
-@UITest
+@UITest(
+    extraJARs = {
+        "org.xwiki.platform:xwiki-platform-eventstream-store-solr"
+    }, resolveExtraJARs = true)
 class TaskManagerIT
 {
     private final DocumentReference pageWithTaskMacros = new DocumentReference("xwiki", "Main", "Test");


### PR DESCRIPTION
The two listeners should be mutually exclusive. Only one should execute at a time.

Additionally, an optimization was made: skip the update of the owner of the task page if it is queued to be deleted by a delete job.
This check will be made when a task page is being deleted.  