### PR TITLE
Change the Task location under a Task Manager page #63

### DIFF
--- a/application-task-api/src/main/java/com/xwiki/task/TaskManager.java
+++ b/application-task-api/src/main/java/com/xwiki/task/TaskManager.java
@@ -21,6 +21,7 @@ package com.xwiki.task;
 
 import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
 import org.xwiki.stability.Unstable;
 
 import com.xwiki.task.model.Task;
@@ -41,6 +42,14 @@ public interface TaskManager
      * @throws TaskException if the page does not have a task.
      */
     Task getTask(DocumentReference reference) throws TaskException;
+
+    /**
+     * @param reference the reference of a page that contains a Task Object.
+     * @return the Task Model of the object inside the page.
+     * @throws TaskException if the page does not have a task.
+     * @since 3.3
+     */
+    Task getTask(EntityReference reference) throws TaskException;
 
     /**
      * @param id the ID of the task.

--- a/application-task-default/src/main/java/com/xwiki/task/internal/DefaultTaskManager.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/DefaultTaskManager.java
@@ -30,6 +30,7 @@ import javax.inject.Singleton;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.query.Query;
@@ -75,6 +76,12 @@ public class DefaultTaskManager implements TaskManager
 
     @Override
     public Task getTask(DocumentReference reference) throws TaskException
+    {
+        return getTask((EntityReference) reference);
+    }
+
+    @Override
+    public Task getTask(EntityReference reference) throws TaskException
     {
         XWikiContext context = contextProvider.get();
         try {

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskBlockProcessor.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskBlockProcessor.java
@@ -78,9 +78,22 @@ public class TaskBlockProcessor
      */
     public Block createTaskLinkBlock(String reference, int taskNumber)
     {
+        return createTaskLinkBlock(reference, taskNumber, ResourceType.DOCUMENT);
+    }
+
+    /**
+     * Create a link block for a task.
+     *
+     * @param reference the reference to the task page.
+     * @param taskNumber the number of the task, that uniquely identifies it.
+     * @param resourceType the resource type of the reference.
+     * @return a {@link LinkBlock} that points to the reference and the number of the task as content.
+     */
+    public Block createTaskLinkBlock(String reference, int taskNumber, ResourceType resourceType)
+    {
         return new LinkBlock(
             Arrays.asList(new SpecialSymbolBlock('#'), new WordBlock(String.valueOf(taskNumber))),
-            new ResourceReference(reference, ResourceType.DOCUMENT),
+            new ResourceReference(reference, resourceType),
             false);
     }
 

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroConverter.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroConverter.java
@@ -22,11 +22,13 @@ package com.xwiki.task.internal;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.contrib.confluence.filter.internal.macros.AbstractMacroConverter;
+import org.xwiki.model.reference.EntityReferenceSerializer;
 
 import com.xwiki.task.model.Task;
 
@@ -47,7 +49,11 @@ public class TaskMacroConverter extends AbstractMacroConverter
 
     private static final String TASK_REFERENCE_PARAMETER = "reference";
 
-    private static final String TASK_REFERENCE_PREFIX = "Task_";
+    private static final String TASK_REFERENCE_PREFIX = "/Tasks/Task_";
+
+    @Inject
+    @Named("compact")
+    private EntityReferenceSerializer<String> serializer;
 
     // A workaround for issue XWIKI-20805 that causes the wysiwyg editor to delete the macros inside the content of
     // another macro when saving the page.

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroConverter.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroConverter.java
@@ -22,13 +22,11 @@ package com.xwiki.task.internal;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.contrib.confluence.filter.internal.macros.AbstractMacroConverter;
-import org.xwiki.model.reference.EntityReferenceSerializer;
 
 import com.xwiki.task.model.Task;
 
@@ -50,10 +48,6 @@ public class TaskMacroConverter extends AbstractMacroConverter
     private static final String TASK_REFERENCE_PARAMETER = "reference";
 
     private static final String TASK_REFERENCE_PREFIX = "/Tasks/Task_";
-
-    @Inject
-    @Named("compact")
-    private EntityReferenceSerializer<String> serializer;
 
     // A workaround for issue XWIKI-20805 that causes the wysiwyg editor to delete the macros inside the content of
     // another macro when saving the page.

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
@@ -23,7 +23,6 @@ package com.xwiki.task.internal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -38,11 +37,11 @@ import org.xwiki.component.annotation.Component;
 import org.xwiki.filter.internal.job.FilterStreamConverterJob;
 import org.xwiki.job.Job;
 import org.xwiki.job.event.status.JobStatus;
-import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceProvider;
 import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.observation.event.Event;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
@@ -211,7 +210,7 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
         for (Task task : tasks) {
             DocumentReference taskReference = task.getReference();
             try {
-                // Create/Update the task page only if its a child of `Parent.Tasks` or if the user has edit rights
+                // Create/Update the task page only if it's a child of `Parent.Tasks` or if the user has edit rights
                 // over it.
                 if (!isChildOfTasksSubspace(taskReference, document.getDocumentReference())
                     && !authorizationManager.hasAccess(Right.EDIT, taskReference))
@@ -252,18 +251,8 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
 
     private boolean isChildOfTasksSubspace(EntityReference possibleChild, DocumentReference possibleParent)
     {
-        String webHome = referenceProvider.getDefaultReference(EntityType.DOCUMENT).getName();
-        if (!possibleParent.getName().equals(webHome)) {
-            // Terminal pages can't have child pages.
-            return false;
-        }
-        EntityReference parentOfChild =
-            possibleChild.getName().equals(webHome) ? possibleChild.getParent().getParent() : possibleChild.getParent();
-        if (!Objects.equals(parentOfChild.getName(), "Tasks")) {
-            // If the task reference is not a child of subspace, the rights of the user should be checked.
-            return false;
-        }
-        return Objects.equals(parentOfChild.getParent(), possibleParent.getLastSpaceReference());
+        SpaceReference expectedParent = new SpaceReference("Tasks", possibleParent.getLastSpaceReference());
+        return possibleChild.hasParent(expectedParent);
     }
 
     private void populateObjectWithMacroParams(XWikiContext context, Task task, BaseObject object)

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskReferenceUtils.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskReferenceUtils.java
@@ -1,0 +1,113 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.task.internal;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.xwiki.bridge.DocumentAccessBridge;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.model.reference.PageReference;
+import org.xwiki.model.reference.PageReferenceResolver;
+
+// TODO: Since 3.3 we use PageReferences for the task reference. However, if the reference is a document
+//  reference that exists, we update that document. This is done for backwards compatibility. To be
+//  removed after ~1 year of the release of v3.3.
+
+/**
+ * A class that handles Task References resolving and serialization.
+ *
+ * @version $Id$
+ * @since 3.3
+ */
+@Component(roles = TaskReferenceUtils.class)
+@Singleton
+public class TaskReferenceUtils
+{
+    @Inject
+    private DocumentAccessBridge documentAccessBridge;
+
+    @Inject
+    private PageReferenceResolver<String> pageReferenceResolver;
+
+    @Inject
+    private DocumentReferenceResolver<String> docStringResolver;
+
+    @Inject
+    private DocumentReferenceResolver<EntityReference> docRefResolver;
+
+    @Inject
+    private EntityReferenceSerializer<String> serializer;
+
+    /**
+     * Receives a string representation of a task reference and, it resolves it as either a document reference (if the
+     * document exists) or a page reference.
+     *
+     * @param representation representation of the task reference. It can be a serialized DocumentReference or
+     *     PageReference.
+     * @param relativeTo the parent of the task reference.
+     * @return either a DocumentReference or a PageReference depending on the representation.
+     */
+    public EntityReference resolve(String representation, EntityReference relativeTo)
+    {
+        DocumentReference docRef = docStringResolver.resolve(representation, relativeTo);
+        if (!documentAccessBridge.exists(docRef)) {
+            return pageReferenceResolver.resolve(representation, relativeTo);
+        }
+        return docRef;
+    }
+
+    /**
+     * Serialize an entity reference as a DocumentReference.
+     *
+     * @param reference either a DocumentReference or a PageReference.
+     * @param relativeTo the parent of the task reference.
+     * @return the reference serialized as a DocumentReference.
+     */
+    public String serializeAsDocumentReference(EntityReference reference, EntityReference relativeTo)
+    {
+        if (reference instanceof DocumentReference) {
+            return serializer.serialize(reference, relativeTo);
+        }
+        DocumentReference documentReference = docRefResolver.resolve(reference);
+        return serializer.serialize(documentReference, relativeTo);
+    }
+
+    /**
+     * Receives a string representation of a task reference and, it resolves it as a document reference.
+     *
+     * @param representation representation of the task reference. It can be a serialized DocumentReference or
+     *     PageReference.
+     * @param relativeTo the parent of the task reference.
+     * @return a DocumentReference.
+     */
+    public DocumentReference resolveAsDocumentReference(String representation, EntityReference relativeTo)
+    {
+        EntityReference reference = resolve(representation, relativeTo);
+        if (reference instanceof PageReference) {
+            return docRefResolver.resolve(reference);
+        }
+        return (DocumentReference) reference;
+    }
+}

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
@@ -36,6 +36,7 @@ import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.PageReferenceResolver;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.XDOM;
@@ -66,6 +67,12 @@ public class TaskXDOMProcessor
 
     @Inject
     private DocumentReferenceResolver<String> resolver;
+
+    @Inject
+    private PageReferenceResolver<String> pageReferenceResolver;
+
+    @Inject
+    private TaskReferenceUtils taskReferenceUtils;
 
     @Inject
     private TaskConfiguration configuration;
@@ -150,8 +157,8 @@ public class TaskXDOMProcessor
     {
         this.blockFinder.find(docContent, syntax, (macro) -> {
             if (Task.MACRO_NAME.equals(macro.getId())) {
-                DocumentReference macroRef =
-                    resolver.resolve(macro.getParameters().getOrDefault(Task.REFERENCE, ""), ownerReference);
+                DocumentReference macroRef = taskReferenceUtils.resolveAsDocumentReference(
+                    macro.getParameters().getOrDefault(Task.REFERENCE, ""), ownerReference);
                 if (macroRef.equals(taskReference)) {
                     List<Block> siblings = macro.getParent().getChildren();
                     siblings.remove(macro);
@@ -173,7 +180,7 @@ public class TaskXDOMProcessor
         if (StringUtils.isEmpty(taskReference)) {
             return null;
         }
-        task.setReference(resolver.resolve(taskReference, contentSource));
+        task.setReference(taskReferenceUtils.resolveAsDocumentReference(taskReference, contentSource));
         extractBasicProperties(macroParams, task);
 
         try {
@@ -197,7 +204,8 @@ public class TaskXDOMProcessor
         DocumentReference taskDocRef, XDOM content, SimpleDateFormat storageFormat, MacroBlock macro)
     {
         DocumentReference taskRef =
-            resolver.resolve(macro.getParameters().getOrDefault(Task.REFERENCE, ""), documentReference);
+            taskReferenceUtils.resolveAsDocumentReference(macro.getParameters().getOrDefault(Task.REFERENCE, ""),
+                documentReference);
         if (taskRef.equals(taskDocRef)) {
 
             setBasicMacroParameters(taskObject, storageFormat, macro);

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
@@ -36,7 +36,6 @@ import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
-import org.xwiki.model.reference.PageReferenceResolver;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.XDOM;
@@ -67,9 +66,6 @@ public class TaskXDOMProcessor
 
     @Inject
     private DocumentReferenceResolver<String> resolver;
-
-    @Inject
-    private PageReferenceResolver<String> pageReferenceResolver;
 
     @Inject
     private TaskReferenceUtils taskReferenceUtils;

--- a/application-task-default/src/main/java/com/xwiki/task/internal/rest/DefaultTaskReferenceResource.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/rest/DefaultTaskReferenceResource.java
@@ -30,6 +30,7 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.model.reference.PageReferenceResolver;
+import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
@@ -66,7 +67,8 @@ public class DefaultTaskReferenceResource extends XWikiResource implements TaskR
     @Override
     public String generateId(String wikiName, String spaces, String pageName) throws XWikiRestException
     {
-        DocumentReference docRef = new DocumentReference(pageName, getSpaceReference(spaces, wikiName));
+        DocumentReference docRef =
+            new DocumentReference(pageName, new SpaceReference("Tasks", getSpaceReference(spaces, wikiName)));
         if (!contextualAuthorizationManager.hasAccess(Right.EDIT, docRef)) {
             throw new WebApplicationException(Response.Status.FORBIDDEN);
         }

--- a/application-task-default/src/main/java/com/xwiki/task/internal/rest/DefaultTaskReferenceResource.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/rest/DefaultTaskReferenceResource.java
@@ -27,7 +27,9 @@ import javax.ws.rs.core.Response;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.model.reference.PageReferenceResolver;
 import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
@@ -58,6 +60,9 @@ public class DefaultTaskReferenceResource extends XWikiResource implements TaskR
     @Named("compact")
     private EntityReferenceSerializer<String> serializer;
 
+    @Inject
+    private PageReferenceResolver<EntityReference> pageReferenceResolver;
+
     @Override
     public String generateId(String wikiName, String spaces, String pageName) throws XWikiRestException
     {
@@ -66,7 +71,7 @@ public class DefaultTaskReferenceResource extends XWikiResource implements TaskR
             throw new WebApplicationException(Response.Status.FORBIDDEN);
         }
         try {
-            return serializer.serialize(taskReferenceGenerator.generate(docRef));
+            return serializer.serialize(pageReferenceResolver.resolve(taskReferenceGenerator.generate(docRef)), docRef);
         } catch (TaskException e) {
             throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
         }

--- a/application-task-default/src/main/resources/META-INF/components.txt
+++ b/application-task-default/src/main/resources/META-INF/components.txt
@@ -9,6 +9,7 @@ com.xwiki.task.internal.TaskBlockProcessor
 com.xwiki.task.internal.TaskDatesInitializer
 com.xwiki.task.internal.TaskListMacroConverter
 com.xwiki.task.internal.TaskMacroConverter
+com.xwiki.task.internal.TaskReferenceUtils
 com.xwiki.task.internal.TaskXDOMProcessor
 com.xwiki.task.internal.TaskMacroUpdateEventListener
 com.xwiki.task.internal.TaskManagerConfigurationSource

--- a/application-task-default/src/test/java/com/xwiki/task/DefaultTaskManagerTest.java
+++ b/application-task-default/src/test/java/com/xwiki/task/DefaultTaskManagerTest.java
@@ -110,6 +110,7 @@ class DefaultTaskManagerTest
         when(this.contextProvider.get()).thenReturn(this.context);
         when(this.context.getWiki()).thenReturn(this.wiki);
         when(this.wiki.getDocument(this.documentReference, this.context)).thenReturn(this.document);
+        when(this.wiki.getDocument((EntityReference) this.documentReference, this.context)).thenReturn(this.document);
         when(this.document.getXObject(any(EntityReference.class))).thenReturn(this.taskObject);
         when(this.resolver.resolve(documentReference.toString())).thenReturn(documentReference);
         when(this.resolver.resolve(userReference.toString())).thenReturn(userReference);

--- a/application-task-default/src/test/java/com/xwiki/task/IntegrationTests.java
+++ b/application-task-default/src/test/java/com/xwiki/task/IntegrationTests.java
@@ -31,6 +31,7 @@ import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReference;
 import org.xwiki.rendering.test.integration.RenderingTestSuite;
 import org.xwiki.script.service.ScriptService;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
@@ -40,10 +41,12 @@ import org.xwiki.test.annotation.AllComponents;
 import org.xwiki.test.mockito.MockitoComponentManager;
 
 import com.xpn.xwiki.XWikiContext;
+import com.xwiki.task.internal.TaskReferenceUtils;
 import com.xwiki.task.model.Task;
 import com.xwiki.task.script.TaskScriptService;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 /**
@@ -83,6 +86,15 @@ public class IntegrationTests
         DocumentReference ref2 = new DocumentReference("xwiki", "Sandbox", "Task2");
         DocumentReference ref3 = new DocumentReference("xwiki", "Sandbox", "Task3");
 
+        TaskReferenceUtils taskReferenceUtils =
+            componentManager.registerMockComponent(TaskReferenceUtils.class);
+        when(taskReferenceUtils.resolve("Sandbox.Task", null)).thenReturn(ref1);
+        when(taskReferenceUtils.resolve("Sandbox.Task2", null)).thenReturn(ref2);
+        when(taskReferenceUtils.resolve("Sandbox.Task3", null)).thenReturn(ref3);
+        when(taskReferenceUtils.serializeAsDocumentReference(eq(ref1), any())).thenReturn("Sandbox.Task");
+        when(taskReferenceUtils.serializeAsDocumentReference(eq(ref2), any())).thenReturn("Sandbox.Task2");
+        when(taskReferenceUtils.serializeAsDocumentReference(eq(ref3), any())).thenReturn("Sandbox.Task3");
+
         Task task = new Task();
         task.setReference(ref1);
         task.setName("Test name");
@@ -109,8 +121,8 @@ public class IntegrationTests
         when(taskManager.getTask(3)).thenReturn(task3);
         when(taskManager.getTask(2)).thenReturn(task2);
         when(taskManager.getTask(1)).thenReturn(task);
-        when(taskManager.getTask(ref1)).thenReturn(task);
-        when(taskManager.getTask(ref2)).thenReturn(task2);
+        when(taskManager.getTask((EntityReference) ref1)).thenReturn(task);
+        when(taskManager.getTask((EntityReference) ref2)).thenReturn(task2);
         when(context.getUserReference()).thenReturn(user);
         when(authorizationManager.hasAccess(Right.VIEW, ref1)).thenReturn(true);
         when(authorizationManager.hasAccess(Right.VIEW, ref2)).thenReturn(true);

--- a/application-task-default/src/test/java/com/xwiki/task/TaskXDOMProcessorTest.java
+++ b/application-task-default/src/test/java/com/xwiki/task/TaskXDOMProcessorTest.java
@@ -52,6 +52,7 @@ import org.xwiki.test.junit5.mockito.MockComponent;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xwiki.task.internal.MacroBlockFinder;
 import com.xwiki.task.internal.TaskBlockProcessor;
+import com.xwiki.task.internal.TaskReferenceUtils;
 import com.xwiki.task.internal.TaskXDOMProcessor;
 import com.xwiki.task.model.Task;
 
@@ -85,6 +86,9 @@ public class TaskXDOMProcessorTest
 
     @MockComponent
     private MacroUtils macroUtils;
+
+    @MockComponent
+    private TaskReferenceUtils taskReferenceUtils;
 
     @MockComponent
     @Named("compactwiki")
@@ -133,8 +137,8 @@ public class TaskXDOMProcessorTest
         Map<String, String> taskMacro2Params = initTaskMacroParams(TASK2_ID, DEFAULT_TASK_DATE_STRING,
             Task.STATUS_DONE, adminReference.toString(), DEFAULT_TASK_DATE_STRING);
         when(this.taskMacro2.getParameters()).thenReturn(taskMacro2Params);
-        when(this.resolver.resolve(TASK1_ID, contentSource)).thenReturn(this.task1Reference);
-        when(this.resolver.resolve(TASK2_ID, contentSource)).thenReturn(this.task2Reference);
+        when(this.taskReferenceUtils.resolveAsDocumentReference(TASK1_ID, contentSource)).thenReturn(this.task1Reference);
+        when(this.taskReferenceUtils.resolveAsDocumentReference(TASK2_ID, contentSource)).thenReturn(this.task2Reference);
         when(this.resolver.resolve(adminReference.toString())).thenReturn(adminReference);
         when(this.configuration.getStorageDateFormat()).thenReturn("dd/MM/yyyy");
         when(this.docContent.getMetaData()).thenReturn(this.metaData);
@@ -156,7 +160,7 @@ public class TaskXDOMProcessorTest
 
         callVisitorLambdaFunction();
 
-        verify(this.resolver).resolve(TASK1_ID, this.contentSource);
+        verify(this.taskReferenceUtils).resolveAsDocumentReference(TASK1_ID, this.contentSource);
         assertEquals(1, result.size());
         Task task = result.get(0);
         assertEquals("TaskContent", task.getName());
@@ -233,7 +237,7 @@ public class TaskXDOMProcessorTest
 
         callVisitorLambdaFunction();
 
-        verify(this.resolver).resolve(TASK1_ID, this.contentSource);
+        verify(this.taskReferenceUtils).resolveAsDocumentReference(TASK1_ID, this.contentSource);
         verify(spyContentChildren).remove(this.taskMacro1);
     }
 

--- a/application-task-ui/src/main/resources/TaskManager/TaskMacroInit.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskMacroInit.xml
@@ -157,11 +157,7 @@ require(['moment-setup'], function () {
         let idInput = modal.find("input[name='reference']");
         $('.modal select[name="status"]').each(initCompleteDate)
         if (idInput.val()) return;
-        // Generate tasks in `Tasks` subspace.
-        let tasksSpaceList = XWiki.Model.resolve(XWiki.currentSpace, XWiki.EntityType.SPACE).getReversedReferenceChain();
-        tasksSpaceList.push('Tasks');
-        let tasksDocRef = new XWiki.DocumentReference(XWiki.currentWiki, tasksSpaceList, 'WebHome');
-        let refGenURL = new XWiki.Document(tasksDocRef).getRestURL() + '/task-reference';
+        let refGenURL = XWiki.currentDocument.getRestURL() + '/task-reference';
         idInput.prop('disabled', true);
         idInput.addClass('loading');
         modal.find('.btn-primary').prop('disabled', true);

--- a/application-task-ui/src/main/resources/TaskManager/TaskMacroInit.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskMacroInit.xml
@@ -157,7 +157,11 @@ require(['moment-setup'], function () {
         let idInput = modal.find("input[name='reference']");
         $('.modal select[name="status"]').each(initCompleteDate)
         if (idInput.val()) return;
-        let refGenURL = XWiki.currentDocument.getRestURL() + '/task-reference';
+        // Generate tasks in `Tasks` subspace.
+        let tasksSpaceList = XWiki.Model.resolve(XWiki.currentSpace, XWiki.EntityType.SPACE).getReversedReferenceChain();
+        tasksSpaceList.push('Tasks');
+        let tasksDocRef = new XWiki.DocumentReference(XWiki.currentWiki, tasksSpaceList, 'WebHome');
+        let refGenURL = new XWiki.Document(tasksDocRef).getRestURL() + '/task-reference';
         idInput.prop('disabled', true);
         idInput.addClass('loading');
         modal.find('.btn-primary').prop('disabled', true);


### PR DESCRIPTION
* When creating a task using the WYSIWYG editor, a reference to the `CurrentPage.Tasks` subspace will be generated
* Whenever resolving a task reference, it will be resolved as a task reference. If the resolved reference doesn't exist, it will be resolved as a PageReference and used as such
* The TaskMacroConverter will generate references in the `Tasks` subspace, relative to the current page.