### PR TITLE
Fix #84 Admin is not allowed to make any change in rights

### DIFF
--- a/application-task-ui/pom.xml
+++ b/application-task-ui/pom.xml
@@ -41,7 +41,8 @@
       TaskManager.WebHome
     </xwiki.extension.licensing.publicDocuments>
     <xwiki.extension.licensing.excludedDocuments>
-      TaskManager.Administration
+      TaskManager.Administration,
+      TaskManager.WebPreferences
     </xwiki.extension.licensing.excludedDocuments>
     <xwiki.extension.name>Task Manager Application (Pro)</xwiki.extension.name>
   </properties>


### PR DESCRIPTION
* Exclude `TaskManager.WebPreferences` from licensing checks as it should be editable by admins.