### PR TITLE
 Skip multiple versions of the same document during fold events #114 

### DIFF
--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
@@ -93,10 +93,6 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
         if (document.getXObject(TASK_CLASS_REFERENCE) != null) {
             return;
         }
-        // Skip when inside filter-job because it generates a lot of save events for each version of the imported doc.
-        if (executor.getCurrentJob(FilterStreamConverterJob.ROOT_GROUP) != null) {
-            return;
-        }
         // If the flag is set, it means that the listener was triggered as a result of a save made by
         // TaskObjectUpdateEventListener which updated some macro calls. Skip the execution.
         if (context.get(TASK_UPDATE_FLAG) != null) {


### PR DESCRIPTION
Closes #114 

In the case of Confluence migrations, if a document with multiple versions is imported, the task listeners will try to process each version. If the document contains multiple tasks in each version, each task page will be updated for each document version.

In order to fix this problem, I tried to process only one version for each document.

Having Doc1 with versions (1,2,3}, Doc2 with versions {1, 2} and Doc3 with versions {1} they will be processed by the listener is the following manner:
-- In the context of a fold event --
1. Listener gets Doc1 v1 - stores it
2. Listener gets Doc1 v2 - since its the same document reference, does nothing
3. Listener gets Doc1 v3 - since its the same document reference, does nothing
4. Listener gets Doc2 v1 - since its different doc, process Doc1 and store Doc2
5. Listener gets Doc2 v2 - since its the same document refenrence, does nothing
-- fold event ended --
6. Listener will eventually get Doc3 v1 after the fold event is finished. Since there is a document reference stored, process it and set it to null.

In the context of confluence migrations, step 6 will always happen quickly after the migration is done. This is because the migration page needs to be saved.

While in other contexts that might not be the case, i believe it is very unlikely to cause an issue. It is bound for a document to be saved sooner than later.

Some benchmarks that test the migration of the package linked here: https://github.com/xwikisas/application-confluence-migrator-pro/issues/151 . The migration package contains a page with many versions and around 100 tasks on it.
Without the improvement:
17.66s
16.59s
16.58s
With the improvement:
5.22s
5.54s
5.18s
Without the task manager installed:
3.32s
3.47s
3.05s
