### PR TITLE
 Add pickers to the Kanban Board parameters #105

### DIFF
--- a/application-task-api/src/main/java/com/xwiki/task/ProjectReference.java
+++ b/application-task-api/src/main/java/com/xwiki/task/ProjectReference.java
@@ -1,0 +1,42 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.xwiki.task;
+import org.xwiki.rendering.listener.reference.ResourceReference;
+import org.xwiki.rendering.listener.reference.ResourceType;
+
+/**
+ * Project reference for macro picker.
+ *
+ * @version $Id$
+ * @since 3.4.4
+ */
+public class ProjectReference extends ResourceReference
+{
+    /**
+     *
+     * @param reference the string value of the reference
+     * @param type the type of the reference
+     */
+    public ProjectReference(String reference, ResourceType type)
+    {
+        super(reference, type);
+    }
+}

--- a/application-task-api/src/main/java/com/xwiki/task/SpaceReference.java
+++ b/application-task-api/src/main/java/com/xwiki/task/SpaceReference.java
@@ -1,0 +1,42 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.task;
+
+import org.xwiki.rendering.listener.reference.ResourceReference;
+import org.xwiki.rendering.listener.reference.ResourceType;
+
+/**
+ * Space reference for picker.
+ *
+ * @version $Id$
+ * @since 3.4.4
+ */
+public class SpaceReference extends ResourceReference
+{
+    /**
+     *
+     * @param reference string value of the reference
+     * @param type the type of the reference
+     */
+    public SpaceReference(String reference, ResourceType type)
+    {
+        super(reference, type);
+    }
+}

--- a/application-task-api/src/main/resources/templates/html_displayer/projectreference/edit.vm
+++ b/application-task-api/src/main/resources/templates/html_displayer/projectreference/edit.vm
@@ -1,0 +1,40 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+#set ($hql =
+  "select prop.value from BaseObject obj, StringProperty prop where obj.className='TaskManager.ProjectClass' and prop.id.id=obj.id and prop.name='project'")
+#set ($projects_names = $services.query.hql($hql).execute())
+<select size="1"
+#foreach ($parameter in $displayer.parameters.entrySet())
+  $escapetool.xml($parameter.key)="$!escapetool.xml($parameter.value)"
+#end
+>
+<option value="">$escapetool.xml($services.localization.render('TaskManager.TaskManagerProjectPickerDefault'))</option>
+#foreach ($rValue in $projects_names)
+  #set ($key = "TaskManager.TaskManagerClass_project_$rValue")
+  #set ($translation = $services.localization.render($key))
+<option value="$rValue">
+  #if ($translation == $key)
+    $rValue
+  #else
+    $translation
+  #end
+</option>
+#end
+</select>

--- a/application-task-api/src/main/resources/templates/html_displayer/spacereference/edit.vm
+++ b/application-task-api/src/main/resources/templates/html_displayer/spacereference/edit.vm
@@ -1,0 +1,27 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+#template('documentTree_macros.vm')
+
+<input class = 'selectize-input items space-picker-kanban-parameter'
+#foreach ($parameter in $displayer.parameters.entrySet())
+  $escapetool.xml($parameter.key)="$!escapetool.xml($parameter.value)"
+#end/>
+#set ($discard = $xwiki.jsx.use('TaskManager.KanbanBoardMacro'))
+

--- a/application-task-ui/src/main/resources/TaskManager/KanbanBoardMacro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/KanbanBoardMacro.xml
@@ -50,6 +50,154 @@ Example:
   <object>
     <name>TaskManager.KanbanBoardMacro</name>
     <number>0</number>
+    <className>XWiki.JavaScriptExtension</className>
+    <guid>95c7dae2-83dd-4870-b65b-821fdb18db32</guid>
+    <class>
+      <name>XWiki.JavaScriptExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <defaultValue>long</defaultValue>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <restricted>0</restricted>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>require(['jquery'], function ($) {
+
+  /**
+   * Handles the fetching of the modal and the lazy loading of the css/js.
+   */
+  $(document).on('click', '.space-picker-kanban-parameter', function () {
+    let URL = new XWiki.Document('SpacePicker', 'TaskManager').getURL('get');
+    $.get(URL)
+      .done(function (data) {
+        $('body').append(`&lt;div class='spacePickerKnbModal'&gt; ${data} &lt;/div&gt;`);
+        $('.kanbanSpacePicker').modal('show');
+        // Initialize UI elements that are lazy loaded.
+        $(document).trigger('xwiki:dom:updated', { 'elements': $('.spacePickerKnbModal').toArray()});
+      })
+      .fail(function(){
+        console.error('Failed to retrieve the space picker modal');
+      });
+  })
+
+  $(document).on('show.bs.modal', '.kanbanSpacePicker', function () {
+    $('.modal.macro-editor-modal.in').hide();
+  })
+
+  $(document).on('hidden.bs.modal', '.kanbanSpacePicker', function () {
+    $('.modal.macro-editor-modal.in').show();
+    // We remove the modal from the page
+    $('.spacePickerKnbModal').remove();
+  })
+  /**
+   * Handles the select button of the modal. If a space is selected it will return it's reference otherwise it will
+   * return an empty string.
+   */
+  $(document).on('click', '.kanbanSpaceSelector', function () {
+    // We remove the modal again
+    selectedSpace = $('.xtree .jstree-clicked:last').attr('id');
+    //Root element and we need to replace with an empty string so we can select all the tasks.
+    if (selectedSpace === 'wiki:xwiki_anchor' || selectedSpace === 'document:xwiki:Main.WebHome_anchor') {
+      selectedSpace = "";
+    }
+    else {
+      selectedSpace = selectedSpace.replace('space:xwiki:', "").replace("_anchor", "");
+
+    }
+    $('.space-picker-kanban-parameter').val(selectedSpace);
+    $('.kanbanSpacePicker').modal('hide');
+    $('.modal.macro-editor-modal.in').show();
+  })
+});
+</code>
+    </property>
+    <property>
+      <name/>
+    </property>
+    <property>
+      <parse/>
+    </property>
+    <property>
+      <use/>
+    </property>
+  </object>
+  <object>
+    <name>TaskManager.KanbanBoardMacro</name>
+    <number>0</number>
     <className>XWiki.StyleSheetExtension</className>
     <guid>7454fc45-d7b0-4d46-aa17-5fd6662a49e9</guid>
     <class>
@@ -87,6 +235,7 @@ Example:
         <name>code</name>
         <number>2</number>
         <prettyName>Code</prettyName>
+        <restricted>0</restricted>
         <rows>20</rows>
         <size>50</size>
         <unmodifiable>0</unmodifiable>
@@ -398,6 +547,7 @@ Example:
     </property>
     <property>
       <code>{{velocity}}
+#set($discard = $xwiki.ssx.use('TaskManager.KanbanBoardMacro'))
 ## The xwql variable is used by the awmkanban macro called from this one.
 #set ($xwql = '')
 #set($user = "$!{xcontext.macro.params.user}")
@@ -528,7 +678,7 @@ Example:
       <name>user</name>
     </property>
     <property>
-      <type/>
+      <type>org.xwiki.user.UserReference</type>
     </property>
   </object>
   <object>
@@ -606,7 +756,7 @@ Example:
       <name>space</name>
     </property>
     <property>
-      <type/>
+      <type>com.xwiki.task.SpaceReference</type>
     </property>
   </object>
   <object>
@@ -684,7 +834,7 @@ Example:
       <name>project</name>
     </property>
     <property>
-      <type/>
+      <type>com.xwiki.task.ProjectReference</type>
     </property>
   </object>
   <object>

--- a/application-task-ui/src/main/resources/TaskManager/SpacePicker.xml
+++ b/application-task-ui/src/main/resources/TaskManager/SpacePicker.xml
@@ -1,0 +1,96 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.5" reference="TaskManager.SpacePicker" locale="">
+  <web>TaskManager</web>
+  <name>SpacePicker</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>Main.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <originalMetadataAuthor>XWiki.superadmin</originalMetadataAuthor>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>SpacePicker</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>
+{{velocity output='false'}}
+#template('display_macros.vm')
+#template('documentTree_macros.vm')
+{{/velocity}}
+{{velocity}}
+#initRequiredSkinExtensions()
+
+
+{{html}}
+  &lt;div class="modal fade kanbanSpacePicker" tabindex="-1" role="dialog" aria-hidden="true"
+    style="z-index:30000"&gt;
+    &lt;div class="modal-dialog" role="document"&gt;
+      &lt;div class="modal-content"&gt;
+        &lt;div class="modal-header"&gt;
+          &lt;h5 class="modal-title"&gt;
+            $escapetool.xml($services.localization.render('TaskManager.TaskManagerSpacePickerModalTitle'))
+          &lt;/h5&gt;
+          &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
+            &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
+          &lt;/button&gt;
+        &lt;/div&gt;
+        &lt;div class="modal-body"&gt;
+          #documentTree({
+            'finder':true,
+            'showWikis': true,
+            'showWikiPrettyName': true,
+            'showDocumentTitle': true,
+            'showObjects': false,
+            'showOnlyViewable': true,
+            'showRoot': false,
+            'showSpaces': true,
+            'showTerminalDocuments': false,
+            'showTranslations': false
+          })
+      &lt;/div&gt;
+        &lt;div class="modal-footer"&gt;
+          &lt;button type="button" class="btn btn-secondary" data-dismiss="modal"&gt;
+            $escapetool.xml($services.localization.render('TaskManager.TaskManagerSpacePickerModalClose'))
+          &lt;/button&gt;
+          &lt;button type="button" class="btn btn-primary kanbanSpaceSelector"&gt;
+            $escapetool.xml($services.localization.render('TaskManager.TaskManagerSpacePickerModalSelect'))
+          &lt;/button&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+{{/html}}
+
+
+#getRequiredSkinExtensions($requiredSkinExtensions)
+## We use the X-XWIKI-HTML-HEAD custom HTTP header to return the required JavaScript and CSS resources. Note that the
+## HTML of the UI element is returned in the response body.
+#set ($discard = $response.setHeader('X-XWIKI-HTML-HEAD', $requiredSkinExtensions))
+{{/velocity}}</content>
+</xwikidoc>

--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerTranslations.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerTranslations.xml
@@ -230,7 +230,14 @@ taskmanager.incompleteTasks.notification.fix.done=Data inferred succesfully
 taskmanager.incompleteTasks.notification.fix.error=Error while trying to infer data
 taskmanager.incompleteTasks.notification.fixAll.inprogress=Starting inferring process..
 taskmanager.incompleteTasks.notification.fixAll.done=Inferring process started
-taskmanager.incompleteTasks.notification.fixAll.error=Failed to start inferring process</content>
+taskmanager.incompleteTasks.notification.fixAll.error=Failed to start inferring process
+
+## Pickers translations
+TaskManager.TaskManagerProjectPickerDefault=None
+TaskManager.TaskManagerSpacePickerModalTitle=Space Picker
+TaskManager.TaskManagerSpacePickerModalClose=Close
+TaskManager.TaskManagerSpacePickerModalSelect=Select space
+  </content>
   <object>
     <name>TaskManager.TaskManagerTranslations</name>
     <number>0</number>


### PR DESCRIPTION
 * Added pickers for all the fields. For the user picker, I've used the already implemented picker. For the project picker, I've created a template that queries all the existing projects and displays them as options. For the space picker, I've made a template that loads an input. When you click on the input, it fetches a modal with the documentTree macro that shows only the spaces. The user has to select a space and then click select. The document reference will be retrieved. If the root is selected, an empty value will be returned, and all the spaces will be queried instead of a specific one.
 Previews: 
 
 
![image](https://github.com/xwikisas/application-task/assets/92780090/fa382d74-b352-4e6b-bf69-d055b689f765)
![image](https://github.com/xwikisas/application-task/assets/92780090/56f1c56e-f7e9-4855-9e41-78d46a29d330)
