### PR TITLE
Depended tasks appear on the same line in View mode #82

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerClass.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerClass.xml
@@ -135,7 +135,7 @@
     #set($taskproject = $task.getProperty('project').value)
     #if($type == 'view')
       ## Begin a list in XWiki Syntax
-      *
+      * ## Without this space the * is not parsed as XWiki syntax
     #elseif($type == 'edit')
       &lt;label class="xwiki-form-listclass" data-project="${taskproject}" for="xwiki-form-dependencies-0-${foreach.index}"&gt;
         &lt;input


### PR DESCRIPTION
 * Fix dependency display
 
![image](https://github.com/user-attachments/assets/1f0aefaf-312d-4b2e-a1ea-834f8066df98)
