### PR TITLE
Column parameter not working in Kanban board macro #142

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/KanbanBoardMacro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/KanbanBoardMacro.xml
@@ -43,6 +43,8 @@
 * ##user## [optional, default=$xcontext.userReference] define the user for who tasks are assigned
 * ##space## [optional, default=TaskManager] define the space to look for tasks
 * ##project## [optional, default=] define the project to look for tasks
+* ##colors## [optional, default=green,blue,orange] define the colors of the Kanban columns
+* ##columns## [optional, default=ToDo,InProgress,Done] define the statuses to display as Kanban columns
 
 Example:
 
@@ -569,7 +571,9 @@ Example:
   #end
   #set($xwql = "$xwql obj.project = '$escapetool.sql($project)'")
 #end
-{{awmkanban className="TaskManager.TaskManagerClass" category="status" title="name" columns="assignee,progress,duedate" width="32%" colors=$escapetool.xml($colors)/}}
+#set ($columns = "$!{xcontext.macro.params.columns}")
+
+{{awmkanban className="TaskManager.TaskManagerClass" category="status" displayedCategoryColumns="$!escapetool.xml($columns)" title="name" columns="assignee,progress,duedate" width="32%" colors=$escapetool.xml($colors)/}}
 {{/velocity}}
 </code>
     </property>

--- a/application-task-ui/src/main/resources/TaskManager/KanbanBoardMacro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/KanbanBoardMacro.xml
@@ -572,7 +572,15 @@ Example:
   #set($xwql = "$xwql obj.project = '$escapetool.sql($project)'")
 #end
 #set ($columns = "$!{xcontext.macro.params.columns}")
-{{awmkanban className="TaskManager.TaskManagerClass" category="status" displayedCategoryColumns="$!escapetool.xml($columns)" title="name" columns="assignee,progress,duedate" width="32%" colors=$escapetool.xml($colors)/}}
+{{awmkanban
+  className="TaskManager.TaskManagerClass"
+  category="status"
+  displayedCategoryColumns="$!escapetool.xml($columns)"
+  title="name"
+  columns="assignee,progress,duedate"
+  width="32%"
+  colors=$escapetool.xml($colors)
+/}}
 {{/velocity}}
 </code>
     </property>

--- a/application-task-ui/src/main/resources/TaskManager/KanbanBoardMacro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/KanbanBoardMacro.xml
@@ -572,7 +572,6 @@ Example:
   #set($xwql = "$xwql obj.project = '$escapetool.sql($project)'")
 #end
 #set ($columns = "$!{xcontext.macro.params.columns}")
-
 {{awmkanban className="TaskManager.TaskManagerClass" category="status" displayedCategoryColumns="$!escapetool.xml($columns)" title="name" columns="assignee,progress,duedate" width="32%" colors=$escapetool.xml($colors)/}}
 {{/velocity}}
 </code>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
   </scm>
   <properties>
     <licensing.version>1.25</licensing.version>
-    <kanban-macro.version>1.3.1</kanban-macro.version>
+    <kanban-macro.version>1.4.0</kanban-macro.version>
     <xwiki.extension.category>application</xwiki.extension.category>
   </properties>
   <modules>


### PR DESCRIPTION
The fix was made mostly on the [contrib macro](https://github.com/xwiki-contrib/macro-kanban/pull/5), and changes were propagated here.
* Updated kanban-macro version to 1.4.0
* Parameter `columns` works now
* Updated documentation