### PR TITLE
My Due Tasks sidepanel shows all assigned tasks #165

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerPanel.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerPanel.xml
@@ -177,7 +177,7 @@
       <content>{{velocity}}
   #panelheader($services.localization.render('taskmanager.panel.paneltitle'))
   #if(!$isGuest)
-  #set($query = "from doc.object(TaskManager.TaskManagerClass) as document where doc.fullName &lt;&gt; 'TaskManager.TaskManagerTemplate' and document.assignee=:currentUser order by document.duedate asc")
+  #set($query = "from doc.object(TaskManager.TaskManagerClass) as document where doc.fullName &lt;&gt; 'TaskManager.TaskManagerTemplate' and document.assignee=:currentUser and document.status &lt;&gt; 'Done' order by document.duedate asc")
   #set($results = $services.query.xwql("$query").bindValue("currentUser", $services.model.serialize($xcontext.userReference,'compactwiki')).setLimit(5).execute())
   #foreach($result in $results)
     #set($object = $xwiki.getDocument($result).getObject('TaskManager.TaskManagerClass'))


### PR DESCRIPTION
* Added filter for not done tasks

Tasks are ordered:
1. No due date
2. Due date in the past (tasks that might be running late)
3. Due date in the future

Tasks with status = `Done` are not shown.

![image](https://github.com/user-attachments/assets/3e88b0d4-f69c-4148-8ff9-7debc892499e)
