### PR TITLE
Date macro: optional parameters should be hidden by default #163

### DIFF
--- a/macro-date/macro-date-api/src/main/java/com/xwiki/date/macro/DateMacroParameters.java
+++ b/macro-date/macro-date-api/src/main/java/com/xwiki/date/macro/DateMacroParameters.java
@@ -22,7 +22,7 @@ package com.xwiki.date.macro;
 import org.xwiki.properties.annotation.PropertyDisplayType;
 import org.xwiki.properties.annotation.PropertyMandatory;
 import org.xwiki.stability.Unstable;
-
+import org.xwiki.properties.annotation.PropertyDisplayHidden;
 import com.xwiki.date.DateType;
 
 /**
@@ -67,6 +67,7 @@ public class DateMacroParameters
     /**
      * @param format see {@link #getFormat()}
      */
+    @PropertyDisplayHidden
     public void setFormat(String format)
     {
         this.format = format;
@@ -83,6 +84,7 @@ public class DateMacroParameters
     /**
      * @param displayFormat see {@link #getDisplayFormat()}
      */
+    @PropertyDisplayHidden
     public void setDisplayFormat(String displayFormat)
     {
         this.displayFormat = displayFormat;


### PR DESCRIPTION
* Marked the "Date Display Format" and "Date Input Format" parameters as hidden, so they are only displayed in the macro modal when a value is set in wiki mode.