### PR TITLE
Updating the task status removes XWiki syntax in the content #81

### DIFF
--- a/application-task-api/src/main/java/com/xwiki/task/model/Task.java
+++ b/application-task-api/src/main/java/com/xwiki/task/model/Task.java
@@ -109,6 +109,11 @@ public class Task
      */
     public static final String PROGRESS = "progress";
 
+    /**
+     * The name of the PROGRESS field.
+     */
+    public static final String DESCRIPTION = "description";
+
     private String name;
 
     private int number;
@@ -132,6 +137,24 @@ public class Task
     private Date completeDate;
 
     private int progress;
+
+    private String description;
+
+    /**
+     * Default constructor.
+     */
+    public Task()
+    {
+
+    }
+
+    /**
+     * @param documentReference the reference to this Task.
+     */
+    public Task(DocumentReference documentReference)
+    {
+        this.reference = documentReference;
+    }
 
     /**
      * @return the reference of the document where this task resides.
@@ -324,5 +347,21 @@ public class Task
     public void setProgress(int progress)
     {
         this.progress = progress;
+    }
+
+    /**
+     * @return the description of the task. It can contain XWiki syntax 2.1.
+     */
+    public String getDescription()
+    {
+        return description;
+    }
+
+    /**
+     * @param description see {@link #getDescription()}.
+     */
+    public void setDescription(String description)
+    {
+        this.description = description;
     }
 }

--- a/application-task-api/src/main/java/com/xwiki/task/model/Task.java
+++ b/application-task-api/src/main/java/com/xwiki/task/model/Task.java
@@ -110,7 +110,7 @@ public class Task
     public static final String PROGRESS = "progress";
 
     /**
-     * The name of the PROGRESS field.
+     * The name of the DESCRIPTION field.
      */
     public static final String DESCRIPTION = "description";
 

--- a/application-task-default/src/main/java/com/xwiki/task/internal/DefaultTaskManager.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/DefaultTaskManager.java
@@ -90,7 +90,9 @@ public class DefaultTaskManager implements TaskManager
             if (obj == null) {
                 throw new TaskException(String.format("The page [%s] does not have a Task Object.", reference));
             }
-            return getTaskFromXObject(obj);
+            Task task = getTaskFromXObject(obj);
+            task.setDescription(doc.getContent());
+            return task;
         } catch (XWikiException e) {
             throw new TaskException(String.format("Failed to retrieve the task from the page [%s]", reference));
         }
@@ -116,9 +118,13 @@ public class DefaultTaskManager implements TaskManager
                 XWikiDocument document = context.getWiki().getDocument(documentReference, context);
                 BaseObject taskObject = document.getXObject(TASK_CLASS_REFERENCE);
                 if (taskObject == null) {
-                    return null;
+                    throw new TaskException(
+                        String.format("Could not retrieve the task object [%s] associated with the task with id [%d]",
+                            documentReference, id));
                 }
-                return getTaskFromXObject(taskObject);
+                Task task = getTaskFromXObject(taskObject);
+                task.setDescription(document.getContent());
+                return task;
             }
             throw new TaskException(String.format("There is no task with the id [%d].", id));
         } catch (QueryException | XWikiException e) {

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
@@ -277,9 +277,7 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
 
     private void populateObjectWithMacroParams(XWikiContext context, Task task, BaseObject object)
     {
-        if (object.getStringValue(Task.NAME).isEmpty()) {
-            object.set(Task.NAME, task.getName(), context);
-        }
+        object.set(Task.NAME, task.getName(), context);
 
         object.set(Task.REPORTER, serializer.serialize(task.getReporter()), context);
 

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
@@ -257,10 +257,6 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
         if (docChanged) {
             taskDoc.setXObject(taskObj.getNumber(), clonedObj);
         }
-        if (!taskDoc.getContent().equals(task.getDescription())) {
-            taskDoc.setContent(task.getDescription());
-            docChanged = true;
-        }
 
         if (taskDoc.isNew()) {
             taskDoc.setHidden(true);

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
@@ -41,6 +41,8 @@ import org.xwiki.observation.event.Event;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
+import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceResolver;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -72,6 +74,10 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
 
     @Inject
     private TaskManager taskManager;
+
+    @Inject
+    @Named("document")
+    private UserReferenceResolver<DocumentReference> userRefResolver;
 
     private DocumentReference lastFoldDocumentReference;
 
@@ -153,7 +159,7 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
         if (document.getOriginalDocument() != null) {
             XWikiDocument previousVersionDoc = document.getOriginalDocument();
             XDOM previousContent = previousVersionDoc.getXDOM();
-            previousDocTasks = this.taskXDOMProcessor.extract(previousContent, document.getDocumentReference());
+            previousDocTasks = this.taskXDOMProcessor.extract(previousContent, document.getDocumentReference(), true);
             List<DocumentReference> currentTasksIds =
                 tasks.stream().map(Task::getReference).collect(Collectors.toList());
             previousDocTasks.removeIf(task -> currentTasksIds.contains(task.getReference()));
@@ -221,22 +227,46 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
                 {
                     continue;
                 }
-                taskDoc.setAuthorReference(context.getUserReference());
 
-                taskObj.set(Task.OWNER, serializer.serialize(document.getDocumentReference(), taskReference), context);
+                boolean docChanged = maybeUpdateTaskDoc(document, context, task, taskObj, taskDoc, taskReference);
 
-                populateObjectWithMacroParams(context, task, taskObj);
-
-                if (taskDoc.isNew()) {
-                    taskDoc.setHidden(true);
+                if (docChanged) {
+                    context.getWiki().saveDocument(taskDoc, "Task updated!", context);
                 }
-
-                context.getWiki().saveDocument(taskDoc, "Task updated!", context);
             } catch (XWikiException e) {
                 logger.error("Failed to retrieve the document that contains the Task Object with id [{}]:",
                     taskReference, e);
             }
         }
+    }
+
+    private boolean maybeUpdateTaskDoc(XWikiDocument document, XWikiContext context, Task task, BaseObject taskObj,
+        XWikiDocument taskDoc, DocumentReference taskReference)
+    {
+        BaseObject clonedObj = taskObj.clone();
+
+        UserReference currentUser = userRefResolver.resolve(context.getUserReference());
+        taskDoc.getAuthors().setEffectiveMetadataAuthor(currentUser);
+
+        clonedObj.set(Task.OWNER, serializer.serialize(document.getDocumentReference(), taskReference),
+            context);
+
+        populateObjectWithMacroParams(context, task, clonedObj);
+
+        boolean docChanged = !clonedObj.getDiff(taskObj, context).isEmpty();
+        if (docChanged) {
+            taskDoc.setXObject(taskObj.getNumber(), clonedObj);
+        }
+        if (!taskDoc.getContent().equals(task.getDescription())) {
+            taskDoc.setContent(task.getDescription());
+            docChanged = true;
+        }
+
+        if (taskDoc.isNew()) {
+            taskDoc.setHidden(true);
+            taskDoc.getAuthors().setCreator(currentUser);
+        }
+        return docChanged;
     }
 
     private boolean isChildOfTasksSubspace(EntityReference possibleChild, DocumentReference possibleParent)
@@ -247,7 +277,9 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
 
     private void populateObjectWithMacroParams(XWikiContext context, Task task, BaseObject object)
     {
-        object.set(Task.NAME, task.getName(), context);
+        if (object.getStringValue(Task.NAME).isEmpty()) {
+            object.set(Task.NAME, task.getName(), context);
+        }
 
         object.set(Task.REPORTER, serializer.serialize(task.getReporter()), context);
 

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskObjectUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskObjectUpdateEventListener.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskObjectUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskObjectUpdateEventListener.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -59,6 +60,9 @@ import com.xwiki.task.model.Task;
 @Singleton
 public class TaskObjectUpdateEventListener extends AbstractTaskEventListener
 {
+    private static final Set<String> TASK_MACRO_FIELDS = Set.of(Task.ASSIGNEE, Task.CREATE_DATE,
+        Task.STATUS, Task.COMPLETE_DATE, Task.REPORTER, Task.DESCRIPTION, Task.DUE_DATE);
+
     private static final LocalDocumentReference TEMPLATE_REFERENCE =
         new LocalDocumentReference("TaskManager", "TaskManagerTemplate");
 
@@ -113,8 +117,7 @@ public class TaskObjectUpdateEventListener extends AbstractTaskEventListener
                 XWikiDocument ownerDocument = context.getWiki().getDocument(taskOwnerRef, context).clone();
                 if (!ownerDocument.isNew()) {
                     ownerDocument.setContent(
-                        taskXDOMProcessor.updateTaskMacroCall(taskOwnerRef, taskObj, ownerDocument.getXDOM(),
-                            ownerDocument.getSyntax()));
+                        taskXDOMProcessor.updateTaskMacroCall(taskObj, ownerDocument, document));
                     context.getWiki().saveDocument(ownerDocument,
                         String.format("Task [%s] has been updated!", taskObj.getDocumentReference()), context);
                 }

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskObjectUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskObjectUpdateEventListener.java
@@ -60,9 +60,6 @@ import com.xwiki.task.model.Task;
 @Singleton
 public class TaskObjectUpdateEventListener extends AbstractTaskEventListener
 {
-    private static final Set<String> TASK_MACRO_FIELDS = Set.of(Task.ASSIGNEE, Task.CREATE_DATE,
-        Task.STATUS, Task.COMPLETE_DATE, Task.REPORTER, Task.DESCRIPTION, Task.DUE_DATE);
-
     private static final LocalDocumentReference TEMPLATE_REFERENCE =
         new LocalDocumentReference("TaskManager", "TaskManagerTemplate");
 

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
@@ -22,18 +22,20 @@ package com.xwiki.task.internal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
-import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.rendering.block.Block;
@@ -44,10 +46,11 @@ import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.rendering.macro.MacroExecutionException;
 import org.xwiki.rendering.syntax.Syntax;
 
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
-import com.xwiki.task.MacroUtils;
-import com.xwiki.task.TaskException;
 import com.xwiki.date.DateMacroConfiguration;
+import com.xwiki.task.MacroUtils;
 import com.xwiki.task.model.Task;
 
 /**
@@ -64,6 +67,10 @@ public class TaskXDOMProcessor
 
     private static final String MENTION_MACRO_ID = "mention";
 
+    private static final String PARAM_REFERENCE = "reference";
+
+    private static final String PARAM_VALUE = "value";
+
     @Inject
     private DocumentReferenceResolver<String> resolver;
 
@@ -75,9 +82,6 @@ public class TaskXDOMProcessor
 
     @Inject
     private Logger logger;
-
-    @Inject
-    private TaskBlockProcessor taskBlockProcessor;
 
     @Inject
     private MacroBlockFinder blockFinder;
@@ -95,14 +99,40 @@ public class TaskXDOMProcessor
      */
     public List<Task> extract(XDOM content, DocumentReference contentSource)
     {
+        return extract(content, contentSource, false);
+    }
+
+    /**
+     * Extracts the existing Tasks that have a reference from a given XDOM.
+     *
+     * @param content the XDOM from which one desires to extract or check for the existence of Tasks.
+     * @param contentSource the source of the document.
+     * @param onlyReferences whether the returned tasks should contain only the references or all the details.
+     * @return a list of found Tasks or an empty list if the XDOM didn't contain any valid task. Where a valid task is
+     *     one that has an id.
+     * @since 3.7.0
+     */
+    public List<Task> extract(XDOM content, DocumentReference contentSource, boolean onlyReferences)
+    {
         List<Task> tasks = new ArrayList<>();
         Syntax syntax = (Syntax) content.getMetaData().getMetaData().getOrDefault(MetaData.SYNTAX, Syntax.XWIKI_2_1);
         blockFinder.find(content, syntax, (macro) -> {
             if (Task.MACRO_NAME.equals(macro.getId())) {
+                String serializedRef = macro.getParameters().get(Task.REFERENCE);
+                if (StringUtils.isEmpty(serializedRef)) {
+                    return MacroBlockFinder.Lookup.SKIP;
+                }
+                DocumentReference taskRef = taskReferenceUtils.resolveAsDocumentReference(serializedRef, contentSource);
+                if (onlyReferences) {
+                    tasks.add(new Task(taskRef));
+                    return MacroBlockFinder.Lookup.CONTINUE;
+                }
                 Task task = initTask(syntax, contentSource, macro);
                 if (task == null) {
                     return MacroBlockFinder.Lookup.SKIP;
                 }
+                task.setReference(taskRef);
+                task.setName(taskRef.getName().equals("WebHome") ? taskRef.getParent().getName() : taskRef.getName());
                 tasks.add(task);
             }
             return MacroBlockFinder.Lookup.CONTINUE;
@@ -113,22 +143,19 @@ public class TaskXDOMProcessor
     /**
      * Parse the content of a document and sync the task macro with a given task object.
      *
-     * @param documentReference the reference to the document that contains the task macro that needs updating.
      * @param taskObject the task object that will be used to update task macro.
-     * @param content the content of the document that needs parsing.
-     * @param syntax the syntax of the document content.
+     * @param ownerDoc the document that maybe contains a task macro call that needs updating.
+     * @param taskDocument the document that contains the task object.
      * @return the modified content.
      */
-    public XDOM updateTaskMacroCall(DocumentReference documentReference, BaseObject taskObject, XDOM content,
-        Syntax syntax)
+    public XDOM updateTaskMacroCall(BaseObject taskObject, XWikiDocument ownerDoc, XWikiDocument taskDocument)
     {
-        DocumentReference taskDocRef = taskObject.getDocumentReference();
+        XDOM content = ownerDoc.getXDOM();
+        Syntax syntax = ownerDoc.getSyntax();
         SimpleDateFormat storageFormat = new SimpleDateFormat(configuration.getStorageDateFormat());
         blockFinder.find(content, syntax, (macro) -> {
             if (Task.MACRO_NAME.equals(macro.getId())) {
-                if (maybeUpdateTaskMacroCall(documentReference, taskObject, taskDocRef, content, storageFormat,
-                    macro))
-                {
+                if (maybeUpdateTaskMacroCall(ownerDoc, taskObject, taskDocument, storageFormat, macro)) {
                     return MacroBlockFinder.Lookup.BREAK;
                 }
                 return MacroBlockFinder.Lookup.SKIP;
@@ -169,25 +196,20 @@ public class TaskXDOMProcessor
     private Task initTask(Syntax syntax, DocumentReference contentSource, MacroBlock macro)
     {
         Map<String, String> macroParams = macro.getParameters();
-        String taskReference = macroParams.get(Task.REFERENCE);
         Task task = new Task();
 
-        if (StringUtils.isEmpty(taskReference)) {
-            return null;
-        }
-        task.setReference(taskReferenceUtils.resolveAsDocumentReference(taskReference, contentSource));
         extractBasicProperties(macroParams, task);
 
         try {
 
             XDOM macroContent = macroUtils.getMacroContentXDOM(macro, syntax);
-            task.setName(macroUtils.renderMacroContent(macroContent.getChildren(), Syntax.PLAIN_1_0));
+            task.setDescription(macro.getContent());
             task.setAssignee(extractAssignedUser(macroContent));
 
             Date deadline = extractDeadlineDate(macroContent);
 
             task.setDuedate(deadline);
-        } catch (MacroExecutionException | ComponentLookupException e) {
+        } catch (MacroExecutionException e) {
             logger.warn("Failed to extract the task with reference [{}] from the content of the page [{}]: [{}].",
                 task.getReference(), contentSource, ExceptionUtils.getRootCauseMessage(e));
             return null;
@@ -195,34 +217,103 @@ public class TaskXDOMProcessor
         return task;
     }
 
-    private boolean maybeUpdateTaskMacroCall(DocumentReference documentReference, BaseObject taskObject,
-        DocumentReference taskDocRef, XDOM content, SimpleDateFormat storageFormat, MacroBlock macro)
+    private boolean maybeUpdateTaskMacroCall(XWikiDocument ownerDoc, BaseObject taskObject,
+        XWikiDocument taskDoc, SimpleDateFormat storageFormat, MacroBlock macro)
     {
         DocumentReference taskRef =
             taskReferenceUtils.resolveAsDocumentReference(macro.getParameters().getOrDefault(Task.REFERENCE, ""),
-                documentReference);
-        if (taskRef.equals(taskDocRef)) {
+                ownerDoc.getDocumentReference());
+        if (taskRef.equals(taskDoc.getDocumentReference())) {
 
             setBasicMacroParameters(taskObject, storageFormat, macro);
 
-            try {
-                Syntax syntax =
-                    (Syntax) content.getMetaData().getMetaData().getOrDefault(MetaData.SYNTAX, Syntax.XWIKI_2_1);
+            maybeSetAssignee(taskObject, taskDoc);
+            maybeSetDeadline(taskObject, taskDoc, storageFormat);
 
-                List<Block> newTaskContentBlocks =
-                    taskBlockProcessor.generateTaskContentBlocks(taskObject.getLargeStringValue(Task.ASSIGNEE),
-                        taskObject.getDateValue(Task.DUE_DATE), taskObject.getStringValue(Task.NAME), storageFormat);
+            macroUtils.updateMacroContent(macro, taskDoc.getContent());
 
-                String newContent = macroUtils.renderMacroContent(newTaskContentBlocks, syntax);
-
-                macroUtils.updateMacroContent(macro, newContent);
-            } catch (ComponentLookupException | TaskException e) {
-                logger.warn("Failed to update the task macro call for the task with reference [{}]: [{}].", taskDocRef,
-                    ExceptionUtils.getRootCauseMessage(e));
-            }
             return true;
         }
         return false;
+    }
+
+    private void maybeSetDeadline(BaseObject taskObject, XWikiDocument taskDoc, SimpleDateFormat storageFormat)
+    {
+        Date deadline = taskObject.getDateValue(Task.DUE_DATE);
+        XDOM taskXDOM = taskDoc.getXDOM();
+        MacroBlock dateBlock = taskXDOM.getFirstBlock(new MacroBlockMatcher(DATE_MACRO_ID),
+            Block.Axes.DESCENDANT);
+        boolean domChanged = false;
+        if (deadline != null) {
+            String formattedDeadline = storageFormat.format(deadline);
+            if (dateBlock == null) {
+                if (taskXDOM.getChildren().size() != 1) {
+                    dateBlock = new MacroBlock(DATE_MACRO_ID, Collections.emptyMap(), false);
+                    taskXDOM.addChild(dateBlock);
+                } else {
+                    dateBlock = new MacroBlock(DATE_MACRO_ID, Collections.emptyMap(), true);
+                    taskXDOM.getChildren().get(0).addChild(dateBlock);
+                }
+            }
+            String valueParam = dateBlock.getParameter(PARAM_VALUE);
+            if (!Objects.equals(valueParam, formattedDeadline)) {
+                domChanged = true;
+                dateBlock.setParameter(PARAM_VALUE, formattedDeadline);
+            }
+        } else {
+            if (dateBlock != null) {
+                domChanged = true;
+                dateBlock.getParent().removeBlock(dateBlock);
+            }
+        }
+        if (domChanged) {
+            try {
+                taskDoc.setContent(taskXDOM);
+            } catch (XWikiException e) {
+                logger.warn("Failed to add date macro with value [{}] in the task description [{}]. Cause: [{}].",
+                    deadline, taskDoc.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
+            }
+        }
+    }
+
+    private void maybeSetAssignee(BaseObject taskObject, XWikiDocument taskDoc)
+    {
+        String assignee = taskObject.getLargeStringValue(Task.ASSIGNEE);
+        XDOM taskXDOM = taskDoc.getXDOM();
+        MacroBlock mentionBlock = taskXDOM.getFirstBlock(new MacroBlockMatcher(MENTION_MACRO_ID),
+            Block.Axes.DESCENDANT);
+        boolean domChanged = false;
+        if (assignee != null && !assignee.isEmpty()) {
+            if (mentionBlock == null) {
+                if (taskXDOM.getChildren().size() != 1) {
+                    mentionBlock = new MacroBlock(MENTION_MACRO_ID, Collections.emptyMap(), false);
+                    taskXDOM.addChild(mentionBlock);
+                } else {
+                    mentionBlock = new MacroBlock(MENTION_MACRO_ID, Collections.emptyMap(), true);
+                    taskXDOM.getChildren().get(0).addChild(mentionBlock);
+                }
+            }
+            String parameterAssignee = mentionBlock.getParameter(PARAM_REFERENCE);
+            if (!Objects.equals(parameterAssignee, assignee)) {
+                domChanged = true;
+                mentionBlock.setParameter(PARAM_REFERENCE, assignee);
+                mentionBlock.setParameter("anchor",
+                    assignee.replace('.', '-') + '-' + RandomStringUtils.random(5, true, false));
+            }
+        } else {
+            if (mentionBlock != null) {
+                domChanged = true;
+                mentionBlock.getParent().removeBlock(mentionBlock);
+            }
+        }
+        if (domChanged) {
+            try {
+                taskDoc.setContent(taskXDOM);
+            } catch (XWikiException e) {
+                logger.warn("Failed to add mention to user [{}] in the description of the task [{}]. Cause: [{}].",
+                    assignee, taskDoc.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
+            }
+        }
     }
 
     private void setBasicMacroParameters(BaseObject taskObject, SimpleDateFormat storageFormat, MacroBlock macro)
@@ -304,7 +395,7 @@ public class TaskXDOMProcessor
             return deadline;
         }
 
-        String dateValue = macro.getParameters().get("value");
+        String dateValue = macro.getParameters().get(PARAM_VALUE);
         try {
             String formatParam = macro.getParameters().get("format");
             deadline = new SimpleDateFormat(formatParam != null && !formatParam.isEmpty() ? formatParam

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
@@ -132,7 +132,7 @@ public class TaskXDOMProcessor
                     return MacroBlockFinder.Lookup.SKIP;
                 }
                 task.setReference(taskRef);
-                task.setName(taskRef.getName().equals("WebHome") ? taskRef.getParent().getName() : taskRef.getName());
+                task.setName(macro.getContent());
                 tasks.add(task);
             }
             return MacroBlockFinder.Lookup.CONTINUE;

--- a/application-task-default/src/main/java/com/xwiki/task/internal/macro/TasksMacro.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/macro/TasksMacro.java
@@ -126,9 +126,16 @@ public class TasksMacro extends AbstractMacro<TasksMacroParameters>
                 taskParams.put(Task.COMPLETE_DATE,
                     task.getCompleteDate() != null ? storageFormat.format(task.getCompleteDate()) : "");
 
-                String taskContent = macroUtils.renderMacroContent(blockProcessor.generateTaskContentBlocks(
-                    task.getAssignee() != null ? serializer.serialize(task.getAssignee()) : null, task.getDueDate(),
-                    task.getName(), storageFormat), context.getSyntax());
+                // Since 3.7.0, we store the content on the Task macro in the `description` property of the Task Object.
+                String taskContent = task.getDescription();
+                // Prior to 3.7.0, the content of the task macro was computed from the `name`, `assignee` and
+                // `deadline` properties.
+                if (taskContent == null || taskContent.trim().isEmpty()) {
+                    taskContent = macroUtils.renderMacroContent(blockProcessor.generateTaskContentBlocks(
+                        task.getAssignee() != null ? serializer.serialize(task.getAssignee()) : null, task.getDueDate(),
+                        task.getName(), storageFormat), context.getSyntax());
+                }
+
 
                 blocks.add(new MacroBlock("task", taskParams, taskContent, false));
             } catch (NumberFormatException | ComponentLookupException | TaskException e) {

--- a/application-task-default/src/main/java/com/xwiki/task/internal/macro/TasksMacro.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/macro/TasksMacro.java
@@ -43,10 +43,10 @@ import org.xwiki.rendering.transformation.MacroTransformationContext;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 
+import com.xwiki.date.DateMacroConfiguration;
 import com.xwiki.task.MacroUtils;
 import com.xwiki.task.TaskException;
 import com.xwiki.task.TaskManager;
-import com.xwiki.date.DateMacroConfiguration;
 import com.xwiki.task.internal.TaskBlockProcessor;
 import com.xwiki.task.macro.TasksMacroParameters;
 import com.xwiki.task.model.Task;
@@ -126,16 +126,12 @@ public class TasksMacro extends AbstractMacro<TasksMacroParameters>
                 taskParams.put(Task.COMPLETE_DATE,
                     task.getCompleteDate() != null ? storageFormat.format(task.getCompleteDate()) : "");
 
-                // Since 3.7.0, we store the content on the Task macro in the `description` property of the Task Object.
-                String taskContent = task.getDescription();
-                // Prior to 3.7.0, the content of the task macro was computed from the `name`, `assignee` and
-                // `deadline` properties.
-                if (taskContent == null || taskContent.trim().isEmpty()) {
-                    taskContent = macroUtils.renderMacroContent(blockProcessor.generateTaskContentBlocks(
-                        task.getAssignee() != null ? serializer.serialize(task.getAssignee()) : null, task.getDueDate(),
-                        task.getName(), storageFormat), context.getSyntax());
-                }
-
+                String taskContent = task.getName();
+                // From 3.7.0, the name of the task objects contain the full content of the task macro. In order to
+                // not break the previous mode of display of already existing tasks, {name assignee duedate}, we need
+                // to make sure whether the name contains any xwiki syntax. After saving a task macro once, the task
+                // name will be updated with the correct value and this check will be redundant.
+                taskContent = maybeGetContentPrior3dot7(context, task, taskContent, storageFormat);
 
                 blocks.add(new MacroBlock("task", taskParams, taskContent, false));
             } catch (NumberFormatException | ComponentLookupException | TaskException e) {
@@ -149,5 +145,19 @@ public class TasksMacro extends AbstractMacro<TasksMacroParameters>
         }
         blocks.addAll(errorList);
         return blocks;
+    }
+
+    // TODO: Remove it  after the release of 3.7.0 is old enough (maybe 1 year).
+    private String maybeGetContentPrior3dot7(MacroTransformationContext context, Task task, String taskContent,
+        SimpleDateFormat storageFormat) throws ComponentLookupException, TaskException
+    {
+        if ((task.getAssignee() != null && !taskContent.contains("{{mention"))
+            || (task.getDueDate() != null && !taskContent.contains("{{date")))
+        {
+            return macroUtils.renderMacroContent(blockProcessor.generateTaskContentBlocks(
+                task.getAssignee() != null ? serializer.serialize(task.getAssignee()) : null, task.getDueDate(),
+                task.getName(), storageFormat), context.getSyntax());
+        }
+        return taskContent;
     }
 }

--- a/application-task-default/src/test/java/com/xwiki/task/TaskMacroUpdateEventListenerTest.java
+++ b/application-task-default/src/test/java/com/xwiki/task/TaskMacroUpdateEventListenerTest.java
@@ -32,6 +32,7 @@ import org.mockito.Mock;
 import org.xwiki.bridge.event.DocumentDeletingEvent;
 import org.xwiki.bridge.event.DocumentUpdatingEvent;
 import org.xwiki.model.EntityType;
+import org.xwiki.model.document.DocumentAuthors;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.EntityReferenceProvider;
@@ -43,6 +44,9 @@ import org.xwiki.security.authorization.Right;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceResolver;
+import org.xwiki.user.internal.document.DocumentUserReference;
 
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
@@ -50,11 +54,13 @@ import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.DocumentRevisionProvider;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.objects.ObjectDiff;
 import com.xwiki.task.internal.AbstractTaskEventListener;
 import com.xwiki.task.internal.TaskMacroUpdateEventListener;
 import com.xwiki.task.internal.TaskXDOMProcessor;
 import com.xwiki.task.model.Task;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -86,6 +92,10 @@ class TaskMacroUpdateEventListenerTest
 
     @MockComponent
     private EntityReferenceProvider referenceProvider;
+
+    @MockComponent
+    @Named("document")
+    private UserReferenceResolver<DocumentReference> userReferenceResolver;
 
     @Mock
     private XWikiContext context;
@@ -120,6 +130,9 @@ class TaskMacroUpdateEventListenerTest
     @Mock
     private BaseObject task_1Obj;
 
+    @Mock
+    private DocumentAuthors documentAuthors;
+
     private final DocumentReference adminRef = new DocumentReference("xwiki", "XWiki", "Admin");
 
     private final DocumentReference pageWithMacro = new DocumentReference("xwiki", "XWiki", "Home");
@@ -127,6 +140,10 @@ class TaskMacroUpdateEventListenerTest
     private final DocumentReference taskPage = new DocumentReference("xwiki", "XWiki", "Task");
 
     private final DocumentReference taskPage_1 = new DocumentReference("xwiki", "XWiki", "Task_1");
+
+    private final DocumentReference userDocRef = new DocumentReference("xwiki", "XWiki", "User1");
+
+    private final UserReference userRef = new DocumentUserReference(userDocRef, true);
 
     private Task task = new Task();
 
@@ -157,11 +174,19 @@ class TaskMacroUpdateEventListenerTest
         when(this.task_1Doc.getXObject(AbstractTaskEventListener.TASK_CLASS_REFERENCE)).thenReturn(this.task_1Obj);
         when(this.task_1Doc.getDocumentReference()).thenReturn(this.taskPage_1);
         when(this.taskObj.getLargeStringValue(Task.OWNER)).thenReturn(this.pageWithMacro.toString());
+        when(this.taskObj.getStringValue(Task.NAME)).thenReturn("");
         when(this.task_1Obj.getLargeStringValue(Task.OWNER)).thenReturn(this.pageWithMacro.toString());
         when(this.resolver.resolve(this.pageWithMacro.toString(), this.taskPage)).thenReturn(this.pageWithMacro);
         when(this.resolver.resolve(this.pageWithMacro.toString(), this.taskPage_1)).thenReturn(this.pageWithMacro);
         when(this.serializer.serialize(this.pageWithMacro, this.taskPage)).thenReturn(this.pageWithMacro.toString());
         when(this.serializer.serialize(this.pageWithMacro, this.taskPage_1)).thenReturn(this.pageWithMacro.toString());
+        when(this.taskDoc.getAuthors()).thenReturn(this.documentAuthors);
+        when(this.taskDoc.getContent()).thenReturn("");
+        when(this.context.getUserReference()).thenReturn(this.userDocRef);
+        when(this.userReferenceResolver.resolve(this.userDocRef)).thenReturn(this.userRef);
+        when(this.taskObj.clone()).thenReturn(this.taskObj);
+        when(this.taskObj.getDiff(this.taskObj, this.context)).thenReturn(
+            Collections.singletonList(mock(ObjectDiff.class)));
 
         task_1.setReference(taskPage_1);
         task_1.setReporter(adminRef);
@@ -173,6 +198,7 @@ class TaskMacroUpdateEventListenerTest
         task_1.setNumber(1);
         task_1.setOwner(pageWithMacro);
         task_1.setCreateDate(date1);
+        task_1.setDescription(TASK_NAME);
 
         task.setReference(taskPage);
         task.setReporter(adminRef);
@@ -184,6 +210,7 @@ class TaskMacroUpdateEventListenerTest
         task.setNumber(2);
         task.setOwner(pageWithMacro);
         task.setCreateDate(date1);
+        task.setDescription(TASK_NAME);
     }
 
     @Test
@@ -199,7 +226,7 @@ class TaskMacroUpdateEventListenerTest
     {
         when(this.taskXDOMProcessor.extract(this.docXDOM, this.pageWithMacro)).thenReturn(
             new ArrayList<>(Collections.singletonList(task)));
-        when(this.taskXDOMProcessor.extract(this.prevVersionDocXDOM, this.pageWithMacro)).thenReturn(
+        when(this.taskXDOMProcessor.extract(this.prevVersionDocXDOM, this.pageWithMacro, true)).thenReturn(
             new ArrayList<>(Collections.singletonList(task_1)));
         when(this.taskDoc.isNew()).thenReturn(true);
         when(this.authorizationManager.hasAccess(Right.EDIT, taskPage)).thenReturn(true);
@@ -208,6 +235,8 @@ class TaskMacroUpdateEventListenerTest
         this.eventListener.onEvent(new DocumentUpdatingEvent(), this.docWithTasks, this.context);
 
         verify(this.taskObj).set(Task.OWNER, this.pageWithMacro.toString(), this.context);
+        verify(this.documentAuthors).setEffectiveMetadataAuthor(this.userRef);
+        verify(this.taskDoc).setContent(TASK_NAME);
         verify(this.wiki).saveDocument(this.taskDoc, "Task updated!", this.context);
         verify(this.wiki).deleteDocument(this.task_1Doc, this.context);
     }

--- a/application-task-default/src/test/java/com/xwiki/task/TaskMacroUpdateEventListenerTest.java
+++ b/application-task-default/src/test/java/com/xwiki/task/TaskMacroUpdateEventListenerTest.java
@@ -236,7 +236,7 @@ class TaskMacroUpdateEventListenerTest
 
         verify(this.taskObj).set(Task.OWNER, this.pageWithMacro.toString(), this.context);
         verify(this.documentAuthors).setEffectiveMetadataAuthor(this.userRef);
-        verify(this.taskDoc).setContent(TASK_NAME);
+        verify(this.taskObj).set(Task.NAME, "Hello there", this.context);
         verify(this.wiki).saveDocument(this.taskDoc, "Task updated!", this.context);
         verify(this.wiki).deleteDocument(this.task_1Doc, this.context);
     }

--- a/application-task-default/src/test/java/com/xwiki/task/TaskXDOMProcessorTest.java
+++ b/application-task-default/src/test/java/com/xwiki/task/TaskXDOMProcessorTest.java
@@ -19,7 +19,6 @@
  */
 package com.xwiki.task;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -44,6 +43,8 @@ import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.parser.ParseException;
+import org.xwiki.rendering.parser.Parser;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
@@ -53,7 +54,6 @@ import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xwiki.date.DateMacroConfiguration;
 import com.xwiki.task.internal.MacroBlockFinder;
-import com.xwiki.task.internal.TaskBlockProcessor;
 import com.xwiki.task.internal.TaskReferenceUtils;
 import com.xwiki.task.internal.TaskXDOMProcessor;
 import com.xwiki.task.model.Task;
@@ -92,6 +92,10 @@ public class TaskXDOMProcessorTest
     @MockComponent
     @Named("compactwiki")
     private EntityReferenceSerializer<String> serializer;
+
+    @MockComponent
+    @Named("xwiki/2.1")
+    private Parser xwikiParser;
 
     @Captor
     private ArgumentCaptor<Function<MacroBlock, MacroBlockFinder.Lookup>> visitorLambdaCaptor;
@@ -137,7 +141,7 @@ public class TaskXDOMProcessorTest
     private final DocumentReference contentSource = new DocumentReference("xwiki", "XWiki", "Doc");
 
     @BeforeEach
-    void setup() throws TaskException, MacroExecutionException, ComponentLookupException
+    void setup() throws TaskException, MacroExecutionException, ComponentLookupException, ParseException
     {
         Map<String, String> taskMacro2Params = initTaskMacroParams(TASK2_ID, DEFAULT_TASK_DATE_STRING,
             Task.STATUS_DONE, adminReference.toString(), DEFAULT_TASK_DATE_STRING);
@@ -160,6 +164,7 @@ public class TaskXDOMProcessorTest
         when(this.taskDocument.getDocumentReference()).thenReturn(task1Reference);
         when(this.ownerDocument.getDocumentReference()).thenReturn(contentSource);
         when(this.taskDocument.getContent()).thenReturn(TASK1_ID);
+        when(this.xwikiParser.parse(any())).thenReturn(this.docContent);
     }
 
     @Test
@@ -178,7 +183,7 @@ public class TaskXDOMProcessorTest
         assertEquals(1, result.size());
         Task task = result.get(0);
         assertEquals(task1Reference.getName(), task.getName());
-        assertEquals(TASK1_ID, task.getDescription());
+        assertEquals(TASK1_ID, task.getName());
         assertEquals(this.task1Reference, task.getReference());
     }
 

--- a/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
+++ b/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
@@ -203,35 +203,36 @@ class TaskManagerIT
     void changeTaskPageAssigneeAndDuedate(TestUtils setup) {
         setup.gotoPage("Task_3", "WebHome");
         TaskManagerViewPage viewPage = new TaskManagerViewPage();
-        // Check initial value.
-        assertEquals("Do this @Admin as late as 2023/01/01 12:00", viewPage.getDescription());
         // Changing the assignee and deadline should update the description/task macro content accordingly.
         viewPage.edit();
         TaskManagerInlinePage inlinePage = new TaskManagerInlinePage();
         inlinePage.setAssignee("XWiki.Admin2");
         inlinePage.setDueDate("01/01/2025 12:00:00");
         inlinePage.clickSaveAndView(true);
-        viewPage = new TaskManagerViewPage();
-        assertEquals("Do this @Admin2 as late as 2025/01/01 12:00", viewPage.getDescription());
+        setup.gotoPage(pageWithComplexTaskMacros);
+        ViewPage pageWithMacro = new ViewPage();
+        assertEquals("#3\nDo this @Admin2 as late as 2025/01/01 12:00", pageWithMacro.getContent());
         // Clearing the assignee and deadline should remove the macro calls from the content.
+        setup.gotoPage("Task_3", "WebHome");
+        viewPage = new TaskManagerViewPage();
         viewPage.edit();
         inlinePage = new TaskManagerInlinePage();
         inlinePage.clearAssignee();
         inlinePage.clearDueDate();
         inlinePage.clickSaveAndView(true);
-        viewPage = new TaskManagerViewPage();
-        assertEquals("Do this  as late as ", viewPage.getDescription());
+        setup.gotoPage(pageWithComplexTaskMacros);
+        pageWithMacro = new ViewPage();
+        assertEquals("#3\nDo this  as late as ", pageWithMacro.getContent());
         // Setting new assignee and deadline should append them at the end of the description.
+        setup.gotoPage("Task_3", "WebHome");
+        viewPage = new TaskManagerViewPage();
         viewPage.edit();
         inlinePage = new TaskManagerInlinePage();
         inlinePage.setAssignee("XWiki.Admin");
         inlinePage.setDueDate("01/01/2025 12:00:00");
         inlinePage.clickSaveAndView(true);
-        viewPage = new TaskManagerViewPage();
-        assertEquals("Do this  as late as @Admin 2025/01/01 12:00", viewPage.getDescription());
-        // Make sure the task macro was also updated.
         setup.gotoPage(pageWithComplexTaskMacros);
-        ViewPage pageWithMacro = new ViewPage();
+        pageWithMacro = new ViewPage();
         assertEquals("#3\nDo this  as late as @Admin 2025/01/01 12:00", pageWithMacro.getContent());
 
     }

--- a/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
+++ b/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
@@ -126,10 +126,10 @@ class TaskManagerIT
         int taskStatusCellIndex = liveTableElement.getColumnIndex("Status") + 1;
         assertEquals(2, liveTableElement.getRowCount());
         WebElement row = liveTableElement.getRow(1);
-        assertEquals("Task_1", liveTableElement.getCell(row, taskTileCellIndex).getText());
+        assertEquals("Do this", liveTableElement.getCell(row, taskTileCellIndex).getText());
         assertEquals("Done", liveTableElement.getCell(row, taskStatusCellIndex).getText());
         row = liveTableElement.getRow(2);
-        assertEquals("Task_2", liveTableElement.getCell(row, taskTileCellIndex).getText());
+        assertEquals("Do this as well", liveTableElement.getCell(row, taskTileCellIndex).getText());
         assertEquals("In Progress", liveTableElement.getCell(row, taskStatusCellIndex).getText());
     }
 

--- a/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
+++ b/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
@@ -126,10 +126,10 @@ class TaskManagerIT
         int taskStatusCellIndex = liveTableElement.getColumnIndex("Status") + 1;
         assertEquals(2, liveTableElement.getRowCount());
         WebElement row = liveTableElement.getRow(1);
-        assertEquals("Do this", liveTableElement.getCell(row, taskTileCellIndex).getText());
+        assertEquals("Task_1", liveTableElement.getCell(row, taskTileCellIndex).getText());
         assertEquals("Done", liveTableElement.getCell(row, taskStatusCellIndex).getText());
         row = liveTableElement.getRow(2);
-        assertEquals("Do this as well", liveTableElement.getCell(row, taskTileCellIndex).getText());
+        assertEquals("Task_2", liveTableElement.getCell(row, taskTileCellIndex).getText());
         assertEquals("In Progress", liveTableElement.getCell(row, taskStatusCellIndex).getText());
     }
 
@@ -191,7 +191,7 @@ class TaskManagerIT
         assertEquals("", taskReport.getCell(row, taskAssigneeCellIndex).getText());
         assertEquals(pageWithTaskMacros.getName(), taskReport.getCell(row, taskLocationCellIndex).getText());
         row = taskReport.getRow(2);
-        assertEquals("#3\nDo this  as late as @Admin 2023/01/01 12:00",
+        assertEquals("#3\nDo this @Admin as late as 2023/01/01 12:00",
             taskReport.getCell(row, taskTileCellIndex).getText());
         assertEquals("01/01/2023 12:00:00", taskReport.getCell(row, taskDeadlineCellIndex).getText());
         assertEquals("Admin", taskReport.getCell(row, taskAssigneeCellIndex).getText());
@@ -200,6 +200,44 @@ class TaskManagerIT
 
     @Test
     @Order(7)
+    void changeTaskPageAssigneeAndDuedate(TestUtils setup) {
+        setup.gotoPage("Task_3", "WebHome");
+        TaskManagerViewPage viewPage = new TaskManagerViewPage();
+        // Check initial value.
+        assertEquals("Do this @Admin as late as 2023/01/01 12:00", viewPage.getDescription());
+        // Changing the assignee and deadline should update the description/task macro content accordingly.
+        viewPage.edit();
+        TaskManagerInlinePage inlinePage = new TaskManagerInlinePage();
+        inlinePage.setAssignee("XWiki.Admin2");
+        inlinePage.setDueDate("01/01/2025 12:00:00");
+        inlinePage.clickSaveAndView(true);
+        viewPage = new TaskManagerViewPage();
+        assertEquals("Do this @Admin2 as late as 2025/01/01 12:00", viewPage.getDescription());
+        // Clearing the assignee and deadline should remove the macro calls from the content.
+        viewPage.edit();
+        inlinePage = new TaskManagerInlinePage();
+        inlinePage.clearAssignee();
+        inlinePage.clearDueDate();
+        inlinePage.clickSaveAndView(true);
+        viewPage = new TaskManagerViewPage();
+        assertEquals("Do this  as late as ", viewPage.getDescription());
+        // Setting new assignee and deadline should append them at the end of the description.
+        viewPage.edit();
+        inlinePage = new TaskManagerInlinePage();
+        inlinePage.setAssignee("XWiki.Admin");
+        inlinePage.setDueDate("01/01/2025 12:00:00");
+        inlinePage.clickSaveAndView(true);
+        viewPage = new TaskManagerViewPage();
+        assertEquals("Do this  as late as @Admin 2025/01/01 12:00", viewPage.getDescription());
+        // Make sure the task macro was also updated.
+        setup.gotoPage(pageWithComplexTaskMacros);
+        ViewPage pageWithMacro = new ViewPage();
+        assertEquals("#3\nDo this  as late as @Admin 2025/01/01 12:00", pageWithMacro.getContent());
+
+    }
+
+    @Test
+    @Order(8)
     void deleteTaskPage(TestUtils setup) throws Exception
     {
         // Deleting the page that contains task macros should also delete the task pages.
@@ -212,7 +250,7 @@ class TaskManagerIT
     }
 
     @Test
-    @Order(8)
+    @Order(9)
     void deleteTaskMacro(TestUtils setup) throws Exception
     {
         // Deleting a task page should also delete the task macro from the owner page.

--- a/application-task-test/application-task-test-pageobjects/src/main/java/org/xwiki/contrib/application/task/test/po/TaskManagerInlinePage.java
+++ b/application-task-test/application-task-test-pageobjects/src/main/java/org/xwiki/contrib/application/task/test/po/TaskManagerInlinePage.java
@@ -19,10 +19,12 @@
  */
 package org.xwiki.contrib.application.task.test.po;
 
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.Select;
 import org.xwiki.test.ui.po.InlinePage;
+import org.xwiki.test.ui.po.SuggestInputElement;
 
 /**
  * Represents a Task entry page being added (inline mode).
@@ -36,7 +38,7 @@ public class TaskManagerInlinePage extends InlinePage
 
     @FindBy(id = CLASS_PREFIX + "name")
     private WebElement nameElement;
-    
+
     @FindBy(id = CLASS_PREFIX + "project")
     private WebElement projectElement;
 
@@ -61,6 +63,11 @@ public class TaskManagerInlinePage extends InlinePage
     @FindBy(id = CLASS_PREFIX + "progress")
     private WebElement progressElement;
 
+    @FindBy(id = "content")
+    private WebElement descriptionElement;
+
+    private SuggestInputElement assigneeSuggestion;
+
     /**
      * @param name the name of the Task entry
      */
@@ -78,7 +85,7 @@ public class TaskManagerInlinePage extends InlinePage
         Select projectSelect = new Select(this.projectElement);
         projectSelect.selectByValue(project);
     }
-    
+
     /**
      * @return The creation date of the task (automatically set)
      */
@@ -92,8 +99,15 @@ public class TaskManagerInlinePage extends InlinePage
      */
     public void setDueDate(String dueDate)
     {
+        this.dueDateElement.click();
         this.dueDateElement.clear();
+        this.dueDateElement.sendKeys(Keys.chord(Keys.CONTROL, "a"));
         this.dueDateElement.sendKeys(dueDate);
+        this.dueDateElement.sendKeys(Keys.ENTER);
+    }
+
+    public void clearDueDate() {
+        this.dueDateElement.clear();
     }
 
     /**
@@ -104,7 +118,7 @@ public class TaskManagerInlinePage extends InlinePage
         Select severitySelect = new Select(this.severityElement);
         severitySelect.selectByValue(severity);
     }
-    
+
     public String getReporter()
     {
         return this.reporterElement.getAttribute("value");
@@ -115,8 +129,15 @@ public class TaskManagerInlinePage extends InlinePage
      */
     public void setAssignee(String assignee)
     {
-        this.assigneeElement.clear();
-        this.assigneeElement.sendKeys(assignee);
+        getAssigneeSuggestion().clear().sendKeys(assignee).waitForSuggestions().sendKeys(Keys.ENTER);
+    }
+
+    /**
+     * Clear the value of the assignee field.
+     * @since 3.7.0
+     */
+    public void clearAssignee() {
+        getAssigneeSuggestion().clear();
     }
 
     /**
@@ -135,5 +156,35 @@ public class TaskManagerInlinePage extends InlinePage
     {
         this.progressElement.clear();
         this.progressElement.sendKeys(progress);
+    }
+
+    /**
+     * @return the text value of the description/content element.
+     * @since 3.7.0
+     */
+    public String getDescription()
+    {
+        return descriptionElement.getText();
+    }
+
+    /**
+     * Clear the description element and set a new value to it.
+     *
+     * @param description the content that will be sent to the element.
+     * @since 3.7.0
+     */
+    public void setDescription(String description)
+    {
+        this.descriptionElement.clear();
+        this.descriptionElement.sendKeys(description);
+    }
+
+    private SuggestInputElement getAssigneeSuggestion()
+    {
+        if (this.assigneeSuggestion != null) {
+            return this.assigneeSuggestion;
+        }
+        this.assigneeSuggestion = new SuggestInputElement(this.assigneeElement);
+        return this.assigneeSuggestion;
     }
 }

--- a/application-task-test/application-task-test-pageobjects/src/main/java/org/xwiki/contrib/application/task/test/po/TaskManagerViewPage.java
+++ b/application-task-test/application-task-test-pageobjects/src/main/java/org/xwiki/contrib/application/task/test/po/TaskManagerViewPage.java
@@ -54,6 +54,9 @@ public class TaskManagerViewPage extends ViewPage
     @FindBy(xpath = "//label[@for=\"" + CLASS_PREFIX + "progress\"]/../../dd/div/div/span")
     private WebElement progressElement;
 
+    @FindBy(xpath = "//label[@for=\"" + CLASS_PREFIX + "description\"]/../../dd/p")
+    private WebElement descriptionElement;
+
     /**
      * Opens the home page.
      */
@@ -88,19 +91,32 @@ public class TaskManagerViewPage extends ViewPage
         return progressElement.getText();
     }
 
-    public String getCreateDate() {
+    public String getCreateDate()
+    {
         return completionDateElement.getText();
     }
 
-    public String getCompletionDate() {
+    public String getCompletionDate()
+    {
         return completionDateElement.getText();
     }
 
-    public String getDueDate() {
+    public String getDueDate()
+    {
         return dueDateElement.getText();
     }
 
-    public String getReporter() {
+    public String getReporter()
+    {
         return reporterElement.getText();
+    }
+
+    /**
+     * @return the description of the task.
+     * @since 3.7.0
+     */
+    public String getDescription()
+    {
+        return descriptionElement.getText();
     }
 }

--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
@@ -31,7 +31,7 @@
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
   <version>1.1</version>
-  <title>#set($name = $!{doc.getObject('TaskManager.TaskManagerClass').getProperty('name').value})#if("$!name" != '')$stringtool.abbreviate($name.trim(), 30)#elseif("$!request.title"!='')$request.title#elseif($doc.documentReference.name != 'WebHome')$doc.documentReference.name#else$doc.documentReference.parent.name#end</title>
+  <title>#if("$!doc.getValue('owner')"!='')#set($name="$!doc.title")#else#set($name="$!doc.getValue('name')")#end#if("$!name"!='')$name#elseif("$!request.title"!='')$request.title#elseif($doc.documentReference.name!='WebHome')$doc.documentReference.name#else$doc.documentReference.parent.name#end</title>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
@@ -133,6 +133,7 @@
         (((
           (% class="form-group" %)
           (((
+          #if ("$!doc.getValue('owner')" == '')
             ## Automatically set task name property from the document name
             ; &lt;label for="TaskManager.TaskManagerClass_0_name"&gt;
                 $services.icon.render('book')
@@ -147,6 +148,12 @@
                 #end
               #end
             :   &lt;input class="form-control" type="input" name="TaskManager.TaskManagerClass_0_name" id="TaskManager.TaskManagerClass_0_name" value="$!escapetool.xml($taskName)"/&gt;
+          #else
+            ; &lt;label for="xwikidoctitleinput"&gt;
+                $escapetool.xml($services.localization.render('core.editors.content.titleField.label'))
+              &lt;/label&gt;
+            : &lt;input type="text" id="xwikidoctitleinput" name="title" value="$!escapetool.xml($!doc.title)" /&gt;
+          #end
           )))
         )))
         (% class="col-xs-12 col-sm-4 col-md-4" %)

--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
@@ -217,11 +217,7 @@
               $services.icon.render('application_view_list')
               $escapetool.xml($doc.displayPrettyName('description', false, false))
             &lt;/label&gt;
-          : #if("$!doc.getValue('owner')" != '')
-            $doc.display('description', 'view')
-            #else
-            $doc.display('description')
-            #end
+          : $doc.display('description')
         )))
         (% class="form-group col-xs-12 col-sm-12 col-md-12" %)
         (((

--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
@@ -210,7 +210,11 @@
               $services.icon.render('application_view_list')
               $escapetool.xml($doc.displayPrettyName('description', false, false))
             &lt;/label&gt;
-          : $doc.display('description')
+          : #if("$!doc.getValue('owner')" != '')
+            $doc.display('description', 'view')
+            #else
+            $doc.display('description')
+            #end
         )))
         (% class="form-group col-xs-12 col-sm-12 col-md-12" %)
         (((

--- a/application-task-ui/src/main/resources/TaskManager/TaskReportResultPage.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskReportResultPage.xml
@@ -70,7 +70,7 @@
     #if ("$!row.number" == '')
       #set ($row.name = $services.localization.render('taskmanager.livetable.noRights'))
     #else
-      #set ($row.name = $doc.getRenderedContent("{{tasks ids='${row.number}'/}}", $doc.syntax))
+      #set ($row.name = $doc.getRenderedContentRestricted("{{tasks ids='${row.number}'/}}", $doc.syntax))
     #end
   #end
   #jsonResponse($map)


### PR DESCRIPTION
* Save the task macro content in the task name property without turning it to plain text
  * Updating the task object will no longer mess up the content
* Hide the task name when editing a task page that has an owner (was created by a task macro) since it contains xwiki syntax but is rendered as plain text
* Do not allow the editing of the task name if the task has an owner
  * Made the page title editable in case the user wants to set a different title to the task
* Display the title of the page in the case of task pages that have an owner (currently, the title is filled with the task name)