### PR TITLE
Default statuses are not editable #180

### DIFF
--- a/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
+++ b/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
@@ -79,6 +79,8 @@ class TaskManagerIT
 
     private static final String TASK_REPORT_MACRO = "{{task-report /}}";
 
+    private static final String USER_NAME = "BOB";
+
     @BeforeAll
     void setup(TestUtils setup)
     {
@@ -315,5 +317,20 @@ class TaskManagerIT
         setup.gotoPage(pageWithComplexTaskMacros);
         viewPage = new ViewPageWithTasks();
         assertEquals(0, viewPage.getTaskMacros().size());
+    }
+
+    @Test
+    @Order(10)
+    void deleteAdminDefaults(TestUtils testUtils)
+    {
+        testUtils.setGlobalRights("", "XWiki." + USER_NAME, "admin", true);
+        testUtils.createUserAndLogin(USER_NAME, "password");
+        TaskAdminPage taskAdminPage = TaskAdminPage.gotoPage();
+        taskAdminPage.forceEdit();
+        List<String> ids = List.of("#projectTable", "#statusTable", "#severityTable");
+        List<Integer> expectedResults = List.of(1, 3, 3);
+        for (int i = 0; i < ids.size(); i++) {
+            assertEquals(expectedResults.get(i), taskAdminPage.countSectionElements(ids.get(i)));
+        }
     }
 }

--- a/application-task-test/application-task-test-pageobjects/src/main/java/org/xwiki/contrib/application/task/test/po/TaskAdminPage.java
+++ b/application-task-test/application-task-test-pageobjects/src/main/java/org/xwiki/contrib/application/task/test/po/TaskAdminPage.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.contrib.application.task.test.po;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.Select;
@@ -44,6 +45,10 @@ public class TaskAdminPage extends AdministrationSectionPage
         return new TaskAdminPage();
     }
 
+    public void forceEdit(){
+        getDriver().findElement(By.cssSelector(".panel-body > a")).click();;
+    }
+
     public TaskAdminPage()
     {
         super(SECTION_ID);
@@ -64,5 +69,10 @@ public class TaskAdminPage extends AdministrationSectionPage
             defaultInlineStatusSelect = new Select(defaultInlineStatusElement);
         }
         return defaultInlineStatusSelect;
+    }
+
+    public int countSectionElements(String sectionId)
+    {
+        return getDriver().findElements(By.cssSelector(sectionId + " .actiondelete")).size();
     }
 }

--- a/application-task-ui/pom.xml
+++ b/application-task-ui/pom.xml
@@ -42,7 +42,14 @@
     </xwiki.extension.licensing.publicDocuments>
     <xwiki.extension.licensing.excludedDocuments>
       TaskManager.Administration,
-      TaskManager.WebPreferences
+      TaskManager.WebPreferences,
+      TaskManager.ToDo,
+      TaskManager.InProgress,
+      TaskManager.Done,
+      TaskManager.Medium,
+      TaskManager.Low,
+      TaskManager.High,
+      TaskManager.Other
     </xwiki.extension.licensing.excludedDocuments>
     <xwiki.extension.name>Task Manager Application (Pro)</xwiki.extension.name>
   </properties>

--- a/application-task-ui/src/main/resources/TaskManager/Done.xml
+++ b/application-task-ui/src/main/resources/TaskManager/Done.xml
@@ -86,4 +86,87 @@
       <status>Done</status>
     </property>
   </object>
+  <object>
+    <name>TaskManager.InProgress</name>
+    <number>1</number>
+    <className>XWiki.XWikiRights</className>
+    <guid>077b6e73-bc5c-4136-bd50-a22df12a6857</guid>
+    <class>
+      <name>XWiki.XWikiRights</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <allow>
+        <defaultValue>1</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>allow</displayType>
+        <name>allow</name>
+        <number>4</number>
+        <prettyName>Allow/Deny</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </allow>
+      <groups>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>groups</name>
+        <number>1</number>
+        <picker>1</picker>
+        <prettyName>Groups</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.GroupsClass</classType>
+      </groups>
+      <levels>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>1</multiSelect>
+        <name>levels</name>
+        <number>2</number>
+        <prettyName>Levels</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>3</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.LevelsClass</classType>
+      </levels>
+      <users>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>users</name>
+        <number>3</number>
+        <picker>1</picker>
+        <prettyName>Users</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.UsersClass</classType>
+      </users>
+    </class>
+    <property>
+      <allow>0</allow>
+    </property>
+    <property>
+      <groups>XWiki.XWikiAllGroup</groups>
+    </property>
+    <property>
+      <levels>edit</levels>
+    </property>
+    <property>
+      <users/>
+    </property>
+  </object>
 </xwikidoc>

--- a/application-task-ui/src/main/resources/TaskManager/Done.xml
+++ b/application-task-ui/src/main/resources/TaskManager/Done.xml
@@ -157,10 +157,10 @@
       </users>
     </class>
     <property>
-      <allow>0</allow>
+      <allow>1</allow>
     </property>
     <property>
-      <groups>XWiki.XWikiAllGroup</groups>
+      <groups>XWiki.XWikiAdminGroup</groups>
     </property>
     <property>
       <levels>edit</levels>

--- a/application-task-ui/src/main/resources/TaskManager/High.xml
+++ b/application-task-ui/src/main/resources/TaskManager/High.xml
@@ -69,4 +69,87 @@
       <severity>High</severity>
     </property>
   </object>
+  <object>
+    <name>TaskManager.InProgress</name>
+    <number>1</number>
+    <className>XWiki.XWikiRights</className>
+    <guid>077b6e73-bc5c-4136-bd50-a22df12a6857</guid>
+    <class>
+      <name>XWiki.XWikiRights</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <allow>
+        <defaultValue>1</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>allow</displayType>
+        <name>allow</name>
+        <number>4</number>
+        <prettyName>Allow/Deny</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </allow>
+      <groups>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>groups</name>
+        <number>1</number>
+        <picker>1</picker>
+        <prettyName>Groups</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.GroupsClass</classType>
+      </groups>
+      <levels>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>1</multiSelect>
+        <name>levels</name>
+        <number>2</number>
+        <prettyName>Levels</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>3</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.LevelsClass</classType>
+      </levels>
+      <users>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>users</name>
+        <number>3</number>
+        <picker>1</picker>
+        <prettyName>Users</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.UsersClass</classType>
+      </users>
+    </class>
+    <property>
+      <allow>0</allow>
+    </property>
+    <property>
+      <groups>XWiki.XWikiAllGroup</groups>
+    </property>
+    <property>
+      <levels>edit</levels>
+    </property>
+    <property>
+      <users/>
+    </property>
+  </object>
 </xwikidoc>

--- a/application-task-ui/src/main/resources/TaskManager/High.xml
+++ b/application-task-ui/src/main/resources/TaskManager/High.xml
@@ -140,10 +140,10 @@
       </users>
     </class>
     <property>
-      <allow>0</allow>
+      <allow>1</allow>
     </property>
     <property>
-      <groups>XWiki.XWikiAllGroup</groups>
+      <groups>XWiki.XWikiAdminGroup</groups>
     </property>
     <property>
       <levels>edit</levels>

--- a/application-task-ui/src/main/resources/TaskManager/InProgress.xml
+++ b/application-task-ui/src/main/resources/TaskManager/InProgress.xml
@@ -86,4 +86,87 @@
       <status>InProgress</status>
     </property>
   </object>
+  <object>
+    <name>TaskManager.InProgress</name>
+    <number>1</number>
+    <className>XWiki.XWikiRights</className>
+    <guid>077b6e73-bc5c-4136-bd50-a22df12a6857</guid>
+    <class>
+      <name>XWiki.XWikiRights</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <allow>
+        <defaultValue>1</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>allow</displayType>
+        <name>allow</name>
+        <number>4</number>
+        <prettyName>Allow/Deny</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </allow>
+      <groups>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>groups</name>
+        <number>1</number>
+        <picker>1</picker>
+        <prettyName>Groups</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.GroupsClass</classType>
+      </groups>
+      <levels>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>1</multiSelect>
+        <name>levels</name>
+        <number>2</number>
+        <prettyName>Levels</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>3</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.LevelsClass</classType>
+      </levels>
+      <users>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>users</name>
+        <number>3</number>
+        <picker>1</picker>
+        <prettyName>Users</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.UsersClass</classType>
+      </users>
+    </class>
+    <property>
+      <allow>0</allow>
+    </property>
+    <property>
+      <groups>XWiki.XWikiAllGroup</groups>
+    </property>
+    <property>
+      <levels>edit</levels>
+    </property>
+    <property>
+      <users/>
+    </property>
+  </object>
 </xwikidoc>

--- a/application-task-ui/src/main/resources/TaskManager/InProgress.xml
+++ b/application-task-ui/src/main/resources/TaskManager/InProgress.xml
@@ -157,10 +157,10 @@
       </users>
     </class>
     <property>
-      <allow>0</allow>
+      <allow>1</allow>
     </property>
     <property>
-      <groups>XWiki.XWikiAllGroup</groups>
+      <groups>XWiki.XWikiAdminGroup</groups>
     </property>
     <property>
       <levels>edit</levels>

--- a/application-task-ui/src/main/resources/TaskManager/Low.xml
+++ b/application-task-ui/src/main/resources/TaskManager/Low.xml
@@ -140,10 +140,10 @@
       </users>
     </class>
     <property>
-      <allow>0</allow>
+      <allow>1</allow>
     </property>
     <property>
-      <groups>XWiki.XWikiAllGroup</groups>
+      <groups>XWiki.XWikiAdminGroup</groups>
     </property>
     <property>
       <levels>edit</levels>

--- a/application-task-ui/src/main/resources/TaskManager/Low.xml
+++ b/application-task-ui/src/main/resources/TaskManager/Low.xml
@@ -69,4 +69,87 @@
       <severity>Low</severity>
     </property>
   </object>
+  <object>
+    <name>TaskManager.InProgress</name>
+    <number>1</number>
+    <className>XWiki.XWikiRights</className>
+    <guid>077b6e73-bc5c-4136-bd50-a22df12a6857</guid>
+    <class>
+      <name>XWiki.XWikiRights</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <allow>
+        <defaultValue>1</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>allow</displayType>
+        <name>allow</name>
+        <number>4</number>
+        <prettyName>Allow/Deny</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </allow>
+      <groups>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>groups</name>
+        <number>1</number>
+        <picker>1</picker>
+        <prettyName>Groups</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.GroupsClass</classType>
+      </groups>
+      <levels>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>1</multiSelect>
+        <name>levels</name>
+        <number>2</number>
+        <prettyName>Levels</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>3</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.LevelsClass</classType>
+      </levels>
+      <users>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>users</name>
+        <number>3</number>
+        <picker>1</picker>
+        <prettyName>Users</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.UsersClass</classType>
+      </users>
+    </class>
+    <property>
+      <allow>0</allow>
+    </property>
+    <property>
+      <groups>XWiki.XWikiAllGroup</groups>
+    </property>
+    <property>
+      <levels>edit</levels>
+    </property>
+    <property>
+      <users/>
+    </property>
+  </object>
 </xwikidoc>

--- a/application-task-ui/src/main/resources/TaskManager/Medium.xml
+++ b/application-task-ui/src/main/resources/TaskManager/Medium.xml
@@ -140,10 +140,10 @@
       </users>
     </class>
     <property>
-      <allow>0</allow>
+      <allow>1</allow>
     </property>
     <property>
-      <groups>XWiki.XWikiAllGroup</groups>
+      <groups>XWiki.XWikiAdminGroup</groups>
     </property>
     <property>
       <levels>edit</levels>

--- a/application-task-ui/src/main/resources/TaskManager/Medium.xml
+++ b/application-task-ui/src/main/resources/TaskManager/Medium.xml
@@ -69,4 +69,87 @@
       <severity>Medium</severity>
     </property>
   </object>
+  <object>
+    <name>TaskManager.InProgress</name>
+    <number>1</number>
+    <className>XWiki.XWikiRights</className>
+    <guid>077b6e73-bc5c-4136-bd50-a22df12a6857</guid>
+    <class>
+      <name>XWiki.XWikiRights</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <allow>
+        <defaultValue>1</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>allow</displayType>
+        <name>allow</name>
+        <number>4</number>
+        <prettyName>Allow/Deny</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </allow>
+      <groups>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>groups</name>
+        <number>1</number>
+        <picker>1</picker>
+        <prettyName>Groups</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.GroupsClass</classType>
+      </groups>
+      <levels>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>1</multiSelect>
+        <name>levels</name>
+        <number>2</number>
+        <prettyName>Levels</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>3</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.LevelsClass</classType>
+      </levels>
+      <users>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>users</name>
+        <number>3</number>
+        <picker>1</picker>
+        <prettyName>Users</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.UsersClass</classType>
+      </users>
+    </class>
+    <property>
+      <allow>0</allow>
+    </property>
+    <property>
+      <groups>XWiki.XWikiAllGroup</groups>
+    </property>
+    <property>
+      <levels>edit</levels>
+    </property>
+    <property>
+      <users/>
+    </property>
+  </object>
 </xwikidoc>

--- a/application-task-ui/src/main/resources/TaskManager/Other.xml
+++ b/application-task-ui/src/main/resources/TaskManager/Other.xml
@@ -69,4 +69,87 @@
       <project>Other</project>
     </property>
   </object>
+  <object>
+    <name>TaskManager.InProgress</name>
+    <number>1</number>
+    <className>XWiki.XWikiRights</className>
+    <guid>077b6e73-bc5c-4136-bd50-a22df12a6857</guid>
+    <class>
+      <name>XWiki.XWikiRights</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <allow>
+        <defaultValue>1</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>allow</displayType>
+        <name>allow</name>
+        <number>4</number>
+        <prettyName>Allow/Deny</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </allow>
+      <groups>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>groups</name>
+        <number>1</number>
+        <picker>1</picker>
+        <prettyName>Groups</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.GroupsClass</classType>
+      </groups>
+      <levels>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>1</multiSelect>
+        <name>levels</name>
+        <number>2</number>
+        <prettyName>Levels</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>3</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.LevelsClass</classType>
+      </levels>
+      <users>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>users</name>
+        <number>3</number>
+        <picker>1</picker>
+        <prettyName>Users</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.UsersClass</classType>
+      </users>
+    </class>
+    <property>
+      <allow>0</allow>
+    </property>
+    <property>
+      <groups>XWiki.XWikiAllGroup</groups>
+    </property>
+    <property>
+      <levels>edit</levels>
+    </property>
+    <property>
+      <users/>
+    </property>
+  </object>
 </xwikidoc>

--- a/application-task-ui/src/main/resources/TaskManager/Other.xml
+++ b/application-task-ui/src/main/resources/TaskManager/Other.xml
@@ -140,10 +140,10 @@
       </users>
     </class>
     <property>
-      <allow>0</allow>
+      <allow>1</allow>
     </property>
     <property>
-      <groups>XWiki.XWikiAllGroup</groups>
+      <groups>XWiki.XWikiAdminGroup</groups>
     </property>
     <property>
       <levels>edit</levels>

--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerTranslations.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerTranslations.xml
@@ -113,7 +113,7 @@ taskmanager.livetable.status=Status
 taskmanager.livetable.severity=Priority
 taskmanager.livetable.reporter=Reporter
 taskmanager.livetable.assignee=Assignee
-taskmanager.livetable.duedate=Due Date
+taskmanager.livetable.duedate=Deadline
 taskmanager.livetable.creationDate=Creation Date
 
 # Gantt Diagram

--- a/application-task-ui/src/main/resources/TaskManager/ToDo.xml
+++ b/application-task-ui/src/main/resources/TaskManager/ToDo.xml
@@ -86,4 +86,87 @@
       <status>ToDo</status>
     </property>
   </object>
+  <object>
+    <name>TaskManager.InProgress</name>
+    <number>1</number>
+    <className>XWiki.XWikiRights</className>
+    <guid>077b6e73-bc5c-4136-bd50-a22df12a6857</guid>
+    <class>
+      <name>XWiki.XWikiRights</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <allow>
+        <defaultValue>1</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>allow</displayType>
+        <name>allow</name>
+        <number>4</number>
+        <prettyName>Allow/Deny</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </allow>
+      <groups>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>groups</name>
+        <number>1</number>
+        <picker>1</picker>
+        <prettyName>Groups</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.GroupsClass</classType>
+      </groups>
+      <levels>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>1</multiSelect>
+        <name>levels</name>
+        <number>2</number>
+        <prettyName>Levels</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>3</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.LevelsClass</classType>
+      </levels>
+      <users>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>users</name>
+        <number>3</number>
+        <picker>1</picker>
+        <prettyName>Users</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.UsersClass</classType>
+      </users>
+    </class>
+    <property>
+      <allow>0</allow>
+    </property>
+    <property>
+      <groups>XWiki.XWikiAllGroup</groups>
+    </property>
+    <property>
+      <levels>edit</levels>
+    </property>
+    <property>
+      <users/>
+    </property>
+  </object>
 </xwikidoc>

--- a/application-task-ui/src/main/resources/TaskManager/ToDo.xml
+++ b/application-task-ui/src/main/resources/TaskManager/ToDo.xml
@@ -157,10 +157,10 @@
       </users>
     </class>
     <property>
-      <allow>0</allow>
+      <allow>1</allow>
     </property>
     <property>
-      <groups>XWiki.XWikiAllGroup</groups>
+      <groups>XWiki.XWikiAdminGroup</groups>
     </property>
     <property>
       <levels>edit</levels>


### PR DESCRIPTION
To be able to delete the default statuses, I had to remove the license from all the pages and update the rights to remove edit rights from the all group.