### PR TITLE
Revert185

### DIFF
--- a/application-task-api/src/main/java/com/xwiki/task/model/Task.java
+++ b/application-task-api/src/main/java/com/xwiki/task/model/Task.java
@@ -109,11 +109,6 @@ public class Task
      */
     public static final String PROGRESS = "progress";
 
-    /**
-     * The name of the DESCRIPTION field.
-     */
-    public static final String DESCRIPTION = "description";
-
     private String name;
 
     private int number;
@@ -137,24 +132,6 @@ public class Task
     private Date completeDate;
 
     private int progress;
-
-    private String description;
-
-    /**
-     * Default constructor.
-     */
-    public Task()
-    {
-
-    }
-
-    /**
-     * @param documentReference the reference to this Task.
-     */
-    public Task(DocumentReference documentReference)
-    {
-        this.reference = documentReference;
-    }
 
     /**
      * @return the reference of the document where this task resides.
@@ -347,21 +324,5 @@ public class Task
     public void setProgress(int progress)
     {
         this.progress = progress;
-    }
-
-    /**
-     * @return the description of the task. It can contain XWiki syntax 2.1.
-     */
-    public String getDescription()
-    {
-        return description;
-    }
-
-    /**
-     * @param description see {@link #getDescription()}.
-     */
-    public void setDescription(String description)
-    {
-        this.description = description;
     }
 }

--- a/application-task-api/src/main/java/com/xwiki/task/model/Task.java
+++ b/application-task-api/src/main/java/com/xwiki/task/model/Task.java
@@ -134,6 +134,21 @@ public class Task
     private int progress;
 
     /**
+     * Default constructor.
+     */
+    public Task()
+    {
+    }
+
+    /**
+     * @param documentReference the reference to this Task.
+     */
+    public Task(DocumentReference documentReference)
+    {
+        this.reference = documentReference;
+    }
+
+    /**
      * @return the reference of the document where this task resides.
      */
     public DocumentReference getOwner()

--- a/application-task-default/src/main/java/com/xwiki/task/internal/DefaultTaskManager.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/DefaultTaskManager.java
@@ -90,9 +90,7 @@ public class DefaultTaskManager implements TaskManager
             if (obj == null) {
                 throw new TaskException(String.format("The page [%s] does not have a Task Object.", reference));
             }
-            Task task = getTaskFromXObject(obj);
-            task.setDescription(doc.getContent());
-            return task;
+            return getTaskFromXObject(obj);
         } catch (XWikiException e) {
             throw new TaskException(String.format("Failed to retrieve the task from the page [%s]", reference));
         }
@@ -118,13 +116,9 @@ public class DefaultTaskManager implements TaskManager
                 XWikiDocument document = context.getWiki().getDocument(documentReference, context);
                 BaseObject taskObject = document.getXObject(TASK_CLASS_REFERENCE);
                 if (taskObject == null) {
-                    throw new TaskException(
-                        String.format("Could not retrieve the task object [%s] associated with the task with id [%d]",
-                            documentReference, id));
+                    return null;
                 }
-                Task task = getTaskFromXObject(taskObject);
-                task.setDescription(document.getContent());
-                return task;
+                return getTaskFromXObject(taskObject);
             }
             throw new TaskException(String.format("There is no task with the id [%d].", id));
         } catch (QueryException | XWikiException e) {

--- a/application-task-default/src/main/java/com/xwiki/task/internal/DefaultTaskManager.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/DefaultTaskManager.java
@@ -116,7 +116,9 @@ public class DefaultTaskManager implements TaskManager
                 XWikiDocument document = context.getWiki().getDocument(documentReference, context);
                 BaseObject taskObject = document.getXObject(TASK_CLASS_REFERENCE);
                 if (taskObject == null) {
-                    return null;
+                    throw new TaskException(
+                        String.format("Could not retrieve the task object [%s] associated with the task with id [%d]",
+                            documentReference, id));
                 }
                 return getTaskFromXObject(taskObject);
             }

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
@@ -41,8 +41,6 @@ import org.xwiki.observation.event.Event;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
-import org.xwiki.user.UserReference;
-import org.xwiki.user.UserReferenceResolver;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -74,10 +72,6 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
 
     @Inject
     private TaskManager taskManager;
-
-    @Inject
-    @Named("document")
-    private UserReferenceResolver<DocumentReference> userRefResolver;
 
     private DocumentReference lastFoldDocumentReference;
 
@@ -159,7 +153,7 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
         if (document.getOriginalDocument() != null) {
             XWikiDocument previousVersionDoc = document.getOriginalDocument();
             XDOM previousContent = previousVersionDoc.getXDOM();
-            previousDocTasks = this.taskXDOMProcessor.extract(previousContent, document.getDocumentReference(), true);
+            previousDocTasks = this.taskXDOMProcessor.extract(previousContent, document.getDocumentReference());
             List<DocumentReference> currentTasksIds =
                 tasks.stream().map(Task::getReference).collect(Collectors.toList());
             previousDocTasks.removeIf(task -> currentTasksIds.contains(task.getReference()));
@@ -227,42 +221,22 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
                 {
                     continue;
                 }
+                taskDoc.setAuthorReference(context.getUserReference());
 
-                boolean docChanged = maybeUpdateTaskDoc(document, context, task, taskObj, taskDoc, taskReference);
+                taskObj.set(Task.OWNER, serializer.serialize(document.getDocumentReference(), taskReference), context);
 
-                if (docChanged) {
-                    context.getWiki().saveDocument(taskDoc, "Task updated!", context);
+                populateObjectWithMacroParams(context, task, taskObj);
+
+                if (taskDoc.isNew()) {
+                    taskDoc.setHidden(true);
                 }
+
+                context.getWiki().saveDocument(taskDoc, "Task updated!", context);
             } catch (XWikiException e) {
                 logger.error("Failed to retrieve the document that contains the Task Object with id [{}]:",
                     taskReference, e);
             }
         }
-    }
-
-    private boolean maybeUpdateTaskDoc(XWikiDocument document, XWikiContext context, Task task, BaseObject taskObj,
-        XWikiDocument taskDoc, DocumentReference taskReference)
-    {
-        BaseObject clonedObj = taskObj.clone();
-
-        UserReference currentUser = userRefResolver.resolve(context.getUserReference());
-        taskDoc.getAuthors().setEffectiveMetadataAuthor(currentUser);
-
-        clonedObj.set(Task.OWNER, serializer.serialize(document.getDocumentReference(), taskReference),
-            context);
-
-        populateObjectWithMacroParams(context, task, clonedObj);
-
-        boolean docChanged = !clonedObj.getDiff(taskObj, context).isEmpty();
-        if (docChanged) {
-            taskDoc.setXObject(taskObj.getNumber(), clonedObj);
-        }
-
-        if (taskDoc.isNew()) {
-            taskDoc.setHidden(true);
-            taskDoc.getAuthors().setCreator(currentUser);
-        }
-        return docChanged;
     }
 
     private boolean isChildOfTasksSubspace(EntityReference possibleChild, DocumentReference possibleParent)

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskObjectUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskObjectUpdateEventListener.java
@@ -113,7 +113,8 @@ public class TaskObjectUpdateEventListener extends AbstractTaskEventListener
                 XWikiDocument ownerDocument = context.getWiki().getDocument(taskOwnerRef, context).clone();
                 if (!ownerDocument.isNew()) {
                     ownerDocument.setContent(
-                        taskXDOMProcessor.updateTaskMacroCall(taskObj, ownerDocument, document));
+                        taskXDOMProcessor.updateTaskMacroCall(taskOwnerRef, taskObj, ownerDocument.getXDOM(),
+                            ownerDocument.getSyntax()));
                     context.getWiki().saveDocument(ownerDocument,
                         String.format("Task [%s] has been updated!", taskObj.getDocumentReference()), context);
                 }

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
@@ -128,7 +128,6 @@ public class TaskXDOMProcessor
                     return MacroBlockFinder.Lookup.SKIP;
                 }
                 task.setReference(taskRef);
-                task.setName(macro.getContent());
                 tasks.add(task);
             }
             return MacroBlockFinder.Lookup.CONTINUE;

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskXDOMProcessor.java
@@ -19,21 +19,16 @@
  */
 package com.xwiki.task.internal;
 
-import java.io.StringReader;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
@@ -47,14 +42,12 @@ import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.block.match.MacroBlockMatcher;
 import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.rendering.macro.MacroExecutionException;
-import org.xwiki.rendering.parser.Parser;
 import org.xwiki.rendering.syntax.Syntax;
 
-import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
-import com.xwiki.date.DateMacroConfiguration;
 import com.xwiki.task.MacroUtils;
-import com.xwiki.task.TaskConfiguration;
+import com.xwiki.task.TaskException;
+import com.xwiki.date.DateMacroConfiguration;
 import com.xwiki.task.model.Task;
 
 /**
@@ -71,12 +64,6 @@ public class TaskXDOMProcessor
 
     private static final String MENTION_MACRO_ID = "mention";
 
-    private static final String PARAM_REFERENCE = "reference";
-
-    private static final String PARAM_VALUE = "value";
-
-    private static final String PARAM_FORMAT = "format";
-
     @Inject
     private DocumentReferenceResolver<String> resolver;
 
@@ -90,17 +77,13 @@ public class TaskXDOMProcessor
     private Logger logger;
 
     @Inject
+    private TaskBlockProcessor taskBlockProcessor;
+
+    @Inject
     private MacroBlockFinder blockFinder;
 
     @Inject
     private MacroUtils macroUtils;
-
-    @Inject
-    private TaskConfiguration taskConfiguration;
-
-    @Inject
-    @Named("xwiki/2.1")
-    private Parser xwikiParser;
 
     /**
      * Extracts the existing Tasks that have a reference from a given XDOM.
@@ -156,19 +139,22 @@ public class TaskXDOMProcessor
     /**
      * Parse the content of a document and sync the task macro with a given task object.
      *
+     * @param documentReference the reference to the document that contains the task macro that needs updating.
      * @param taskObject the task object that will be used to update task macro.
-     * @param ownerDoc the document that maybe contains a task macro call that needs updating.
-     * @param taskDocument the document that contains the task object.
+     * @param content the content of the document that needs parsing.
+     * @param syntax the syntax of the document content.
      * @return the modified content.
      */
-    public XDOM updateTaskMacroCall(BaseObject taskObject, XWikiDocument ownerDoc, XWikiDocument taskDocument)
+    public XDOM updateTaskMacroCall(DocumentReference documentReference, BaseObject taskObject, XDOM content,
+        Syntax syntax)
     {
-        XDOM content = ownerDoc.getXDOM();
-        Syntax syntax = ownerDoc.getSyntax();
+        DocumentReference taskDocRef = taskObject.getDocumentReference();
         SimpleDateFormat storageFormat = new SimpleDateFormat(configuration.getStorageDateFormat());
         blockFinder.find(content, syntax, (macro) -> {
             if (Task.MACRO_NAME.equals(macro.getId())) {
-                if (maybeUpdateTaskMacroCall(ownerDoc, taskObject, taskDocument, storageFormat, macro)) {
+                if (maybeUpdateTaskMacroCall(documentReference, taskObject, taskDocRef, content, storageFormat,
+                    macro))
+                {
                     return MacroBlockFinder.Lookup.BREAK;
                 }
                 return MacroBlockFinder.Lookup.CONTINUE;
@@ -216,12 +202,13 @@ public class TaskXDOMProcessor
         try {
 
             XDOM macroContent = macroUtils.getMacroContentXDOM(macro, syntax);
+            task.setName(macroUtils.renderMacroContent(macroContent.getChildren(), Syntax.PLAIN_1_0));
             task.setAssignee(extractAssignedUser(macroContent));
 
             Date deadline = extractDeadlineDate(macroContent);
 
             task.setDuedate(deadline);
-        } catch (MacroExecutionException e) {
+        } catch (MacroExecutionException | ComponentLookupException e) {
             logger.warn("Failed to extract the task with reference [{}] from the content of the page [{}]: [{}].",
                 task.getReference(), contentSource, ExceptionUtils.getRootCauseMessage(e));
             return null;
@@ -229,118 +216,34 @@ public class TaskXDOMProcessor
         return task;
     }
 
-    private boolean maybeUpdateTaskMacroCall(XWikiDocument ownerDoc, BaseObject taskObject,
-        XWikiDocument taskDoc, SimpleDateFormat storageFormat, MacroBlock macro)
+    private boolean maybeUpdateTaskMacroCall(DocumentReference documentReference, BaseObject taskObject,
+        DocumentReference taskDocRef, XDOM content, SimpleDateFormat storageFormat, MacroBlock macro)
     {
         DocumentReference taskRef =
             taskReferenceUtils.resolveAsDocumentReference(macro.getParameters().getOrDefault(Task.REFERENCE, ""),
-                ownerDoc.getDocumentReference());
-        if (taskRef.equals(taskDoc.getDocumentReference())) {
+                documentReference);
+        if (taskRef.equals(taskDocRef)) {
 
             setBasicMacroParameters(taskObject, storageFormat, macro);
 
-            XDOM parsedTaskName;
             try {
-                parsedTaskName = xwikiParser.parse(new StringReader(taskObject.getStringValue(Task.NAME)));
-            } catch (org.xwiki.rendering.parser.ParseException e) {
-                logger.warn("Failed to update the task macro identified by [{}]. Cause: [{}].", taskRef,
+                Syntax syntax =
+                    (Syntax) content.getMetaData().getMetaData().getOrDefault(MetaData.SYNTAX, Syntax.XWIKI_2_1);
+
+                List<Block> newTaskContentBlocks =
+                    taskBlockProcessor.generateTaskContentBlocks(taskObject.getLargeStringValue(Task.ASSIGNEE),
+                        taskObject.getDateValue(Task.DUE_DATE), taskObject.getStringValue(Task.NAME), storageFormat);
+
+                String newContent = macroUtils.renderMacroContent(newTaskContentBlocks, syntax);
+
+                macroUtils.updateMacroContent(macro, newContent);
+            } catch (ComponentLookupException | TaskException e) {
+                logger.warn("Failed to update the task macro call for the task with reference [{}]: [{}].", taskDocRef,
                     ExceptionUtils.getRootCauseMessage(e));
-                return true;
             }
-
-            maybeSetAssignee(taskObject, parsedTaskName);
-            maybeSetDeadline(taskObject, parsedTaskName, storageFormat);
-
-            macroUtils.updateMacroContent(macro, taskObject.getStringValue(Task.NAME));
-
             return true;
         }
         return false;
-    }
-
-    private void maybeSetDeadline(BaseObject taskObject, XDOM parsedName, SimpleDateFormat storageFormat)
-    {
-        Date deadline = taskObject.getDateValue(Task.DUE_DATE);
-        MacroBlock dateBlock = parsedName.getFirstBlock(new MacroBlockMatcher(DATE_MACRO_ID),
-            Block.Axes.DESCENDANT);
-        boolean domChanged = false;
-        if (deadline != null) {
-            if (dateBlock == null) {
-                if (parsedName.getChildren().size() != 1) {
-                    dateBlock = new MacroBlock(DATE_MACRO_ID, Collections.emptyMap(), false);
-                    parsedName.addChild(dateBlock);
-                } else {
-                    dateBlock = new MacroBlock(DATE_MACRO_ID, Collections.emptyMap(), true);
-                    parsedName.getChildren().get(0).addChild(dateBlock);
-                }
-            }
-            String formattedDeadline = storageFormat.format(deadline);
-
-            String formatParam = dateBlock.getParameter(PARAM_FORMAT);
-            if (formatParam != null && !formatParam.isEmpty()) {
-                formattedDeadline = new SimpleDateFormat(formatParam).format(deadline);
-            }
-
-            String valueParam = dateBlock.getParameter(PARAM_VALUE);
-            if (!Objects.equals(valueParam, formattedDeadline)) {
-                domChanged = true;
-                dateBlock.setParameter(PARAM_VALUE, formattedDeadline);
-            }
-        } else {
-            if (dateBlock != null) {
-                domChanged = true;
-                dateBlock.getParent().removeBlock(dateBlock);
-            }
-        }
-        if (domChanged) {
-            try {
-                taskObject.setLargeStringValue(Task.NAME,
-                    macroUtils.renderMacroContent(parsedName.getChildren(), Syntax.XWIKI_2_1));
-            } catch (ComponentLookupException e) {
-                logger.warn("Failed to add date macro with value [{}] in the task name [{}]. Cause: [{}].",
-                    deadline, taskObject.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
-            }
-        }
-    }
-
-    private void maybeSetAssignee(BaseObject taskObject, XDOM parsedName)
-    {
-        String assignee = taskObject.getLargeStringValue(Task.ASSIGNEE);
-        MacroBlock mentionBlock = parsedName.getFirstBlock(new MacroBlockMatcher(MENTION_MACRO_ID),
-            Block.Axes.DESCENDANT);
-        boolean domChanged = false;
-        if (assignee != null && !assignee.isEmpty()) {
-            if (mentionBlock == null) {
-                if (parsedName.getChildren().size() != 1) {
-                    mentionBlock = new MacroBlock(MENTION_MACRO_ID, Collections.emptyMap(), false);
-                    parsedName.addChild(mentionBlock);
-                } else {
-                    mentionBlock = new MacroBlock(MENTION_MACRO_ID, Collections.emptyMap(), true);
-                    parsedName.getChildren().get(0).addChild(mentionBlock);
-                }
-            }
-            String parameterAssignee = mentionBlock.getParameter(PARAM_REFERENCE);
-            if (!Objects.equals(parameterAssignee, assignee)) {
-                domChanged = true;
-                mentionBlock.setParameter(PARAM_REFERENCE, assignee);
-                mentionBlock.setParameter("anchor",
-                    assignee.replace('.', '-') + '-' + RandomStringUtils.random(5, true, false));
-            }
-        } else {
-            if (mentionBlock != null) {
-                domChanged = true;
-                mentionBlock.getParent().removeBlock(mentionBlock);
-            }
-        }
-        if (domChanged) {
-            try {
-                taskObject.setLargeStringValue(Task.NAME,
-                    macroUtils.renderMacroContent(parsedName.getChildren(), Syntax.XWIKI_2_1));
-            } catch (ComponentLookupException e) {
-                logger.warn("Failed to add mention to user [{}] in the description of the task [{}]. Cause: [{}].",
-                    assignee, taskObject.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
-            }
-        }
     }
 
     private void setBasicMacroParameters(BaseObject taskObject, SimpleDateFormat storageFormat, MacroBlock macro)
@@ -371,7 +274,7 @@ public class TaskXDOMProcessor
             task.setReporter(resolver.resolve(reporter));
         }
 
-        String taskStatus = macroParams.getOrDefault(Task.STATUS, taskConfiguration.getDefaultInlineStatus());
+        String taskStatus = macroParams.getOrDefault(Task.STATUS, Task.STATUS_IN_PROGRESS);
         task.setStatus(taskStatus);
 
         String strCreateDate = macroParams.getOrDefault(Task.CREATE_DATE, "");
@@ -422,9 +325,9 @@ public class TaskXDOMProcessor
             return deadline;
         }
 
-        String dateValue = macro.getParameters().get(PARAM_VALUE);
+        String dateValue = macro.getParameters().get("value");
         try {
-            String formatParam = macro.getParameters().get(PARAM_FORMAT);
+            String formatParam = macro.getParameters().get("format");
             deadline = new SimpleDateFormat(formatParam != null && !formatParam.isEmpty() ? formatParam
                 : configuration.getStorageDateFormat()).parse(dateValue);
         } catch (ParseException e) {

--- a/application-task-default/src/test/java/com/xwiki/task/TaskMacroUpdateEventListenerTest.java
+++ b/application-task-default/src/test/java/com/xwiki/task/TaskMacroUpdateEventListenerTest.java
@@ -32,7 +32,6 @@ import org.mockito.Mock;
 import org.xwiki.bridge.event.DocumentDeletingEvent;
 import org.xwiki.bridge.event.DocumentUpdatingEvent;
 import org.xwiki.model.EntityType;
-import org.xwiki.model.document.DocumentAuthors;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.EntityReferenceProvider;
@@ -44,9 +43,6 @@ import org.xwiki.security.authorization.Right;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
-import org.xwiki.user.UserReference;
-import org.xwiki.user.UserReferenceResolver;
-import org.xwiki.user.internal.document.DocumentUserReference;
 
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
@@ -54,13 +50,11 @@ import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.DocumentRevisionProvider;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
-import com.xpn.xwiki.objects.ObjectDiff;
 import com.xwiki.task.internal.AbstractTaskEventListener;
 import com.xwiki.task.internal.TaskMacroUpdateEventListener;
 import com.xwiki.task.internal.TaskXDOMProcessor;
 import com.xwiki.task.model.Task;
 
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -92,10 +86,6 @@ class TaskMacroUpdateEventListenerTest
 
     @MockComponent
     private EntityReferenceProvider referenceProvider;
-
-    @MockComponent
-    @Named("document")
-    private UserReferenceResolver<DocumentReference> userReferenceResolver;
 
     @Mock
     private XWikiContext context;
@@ -130,9 +120,6 @@ class TaskMacroUpdateEventListenerTest
     @Mock
     private BaseObject task_1Obj;
 
-    @Mock
-    private DocumentAuthors documentAuthors;
-
     private final DocumentReference adminRef = new DocumentReference("xwiki", "XWiki", "Admin");
 
     private final DocumentReference pageWithMacro = new DocumentReference("xwiki", "XWiki", "Home");
@@ -140,10 +127,6 @@ class TaskMacroUpdateEventListenerTest
     private final DocumentReference taskPage = new DocumentReference("xwiki", "XWiki", "Task");
 
     private final DocumentReference taskPage_1 = new DocumentReference("xwiki", "XWiki", "Task_1");
-
-    private final DocumentReference userDocRef = new DocumentReference("xwiki", "XWiki", "User1");
-
-    private final UserReference userRef = new DocumentUserReference(userDocRef, true);
 
     private Task task = new Task();
 
@@ -174,19 +157,11 @@ class TaskMacroUpdateEventListenerTest
         when(this.task_1Doc.getXObject(AbstractTaskEventListener.TASK_CLASS_REFERENCE)).thenReturn(this.task_1Obj);
         when(this.task_1Doc.getDocumentReference()).thenReturn(this.taskPage_1);
         when(this.taskObj.getLargeStringValue(Task.OWNER)).thenReturn(this.pageWithMacro.toString());
-        when(this.taskObj.getStringValue(Task.NAME)).thenReturn("");
         when(this.task_1Obj.getLargeStringValue(Task.OWNER)).thenReturn(this.pageWithMacro.toString());
         when(this.resolver.resolve(this.pageWithMacro.toString(), this.taskPage)).thenReturn(this.pageWithMacro);
         when(this.resolver.resolve(this.pageWithMacro.toString(), this.taskPage_1)).thenReturn(this.pageWithMacro);
         when(this.serializer.serialize(this.pageWithMacro, this.taskPage)).thenReturn(this.pageWithMacro.toString());
         when(this.serializer.serialize(this.pageWithMacro, this.taskPage_1)).thenReturn(this.pageWithMacro.toString());
-        when(this.taskDoc.getAuthors()).thenReturn(this.documentAuthors);
-        when(this.taskDoc.getContent()).thenReturn("");
-        when(this.context.getUserReference()).thenReturn(this.userDocRef);
-        when(this.userReferenceResolver.resolve(this.userDocRef)).thenReturn(this.userRef);
-        when(this.taskObj.clone()).thenReturn(this.taskObj);
-        when(this.taskObj.getDiff(this.taskObj, this.context)).thenReturn(
-            Collections.singletonList(mock(ObjectDiff.class)));
 
         task_1.setReference(taskPage_1);
         task_1.setReporter(adminRef);
@@ -198,7 +173,6 @@ class TaskMacroUpdateEventListenerTest
         task_1.setNumber(1);
         task_1.setOwner(pageWithMacro);
         task_1.setCreateDate(date1);
-        task_1.setDescription(TASK_NAME);
 
         task.setReference(taskPage);
         task.setReporter(adminRef);
@@ -210,7 +184,6 @@ class TaskMacroUpdateEventListenerTest
         task.setNumber(2);
         task.setOwner(pageWithMacro);
         task.setCreateDate(date1);
-        task.setDescription(TASK_NAME);
     }
 
     @Test
@@ -226,7 +199,7 @@ class TaskMacroUpdateEventListenerTest
     {
         when(this.taskXDOMProcessor.extract(this.docXDOM, this.pageWithMacro)).thenReturn(
             new ArrayList<>(Collections.singletonList(task)));
-        when(this.taskXDOMProcessor.extract(this.prevVersionDocXDOM, this.pageWithMacro, true)).thenReturn(
+        when(this.taskXDOMProcessor.extract(this.prevVersionDocXDOM, this.pageWithMacro)).thenReturn(
             new ArrayList<>(Collections.singletonList(task_1)));
         when(this.taskDoc.isNew()).thenReturn(true);
         when(this.authorizationManager.hasAccess(Right.EDIT, taskPage)).thenReturn(true);
@@ -235,8 +208,6 @@ class TaskMacroUpdateEventListenerTest
         this.eventListener.onEvent(new DocumentUpdatingEvent(), this.docWithTasks, this.context);
 
         verify(this.taskObj).set(Task.OWNER, this.pageWithMacro.toString(), this.context);
-        verify(this.documentAuthors).setEffectiveMetadataAuthor(this.userRef);
-        verify(this.taskObj).set(Task.NAME, "Hello there", this.context);
         verify(this.wiki).saveDocument(this.taskDoc, "Task updated!", this.context);
         verify(this.wiki).deleteDocument(this.task_1Doc, this.context);
     }

--- a/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
+++ b/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
@@ -184,7 +184,7 @@ class TaskManagerIT
         ViewPageWithTasks viewPage = new ViewPageWithTasks();
         LiveTableElement taskReport = viewPage.getTaskReportLiveTable();
         taskReport.waitUntilReady();
-        assertEquals(2, taskReport.getRowCount());
+        assertEquals(3, taskReport.getRowCount());
         int taskTileCellIndex = taskReport.getColumnIndex("Task") + 1;
         int taskDeadlineCellIndex = taskReport.getColumnIndex("Deadline") + 1;
         int taskAssigneeCellIndex = taskReport.getColumnIndex("Assignee") + 1;
@@ -194,8 +194,8 @@ class TaskManagerIT
         assertEquals("-", taskReport.getCell(row, taskDeadlineCellIndex).getText());
         assertEquals("", taskReport.getCell(row, taskAssigneeCellIndex).getText());
         assertEquals(pageWithTaskMacros.getName(), taskReport.getCell(row, taskLocationCellIndex).getText());
-        row = taskReport.getRow(2);
-        assertEquals("#3\nDo this  as late as @Admin 2023/01/01 12:00",
+        row = taskReport.getRow(3);
+        assertEquals("#3\nDo this @Admin as late as 2023/01/01 12:00",
             taskReport.getCell(row, taskTileCellIndex).getText());
         assertEquals("01/01/2023 12:00:00", taskReport.getCell(row, taskDeadlineCellIndex).getText());
         assertEquals("Admin", taskReport.getCell(row, taskAssigneeCellIndex).getText());

--- a/application-task-test/application-task-test-pageobjects/src/main/java/org/xwiki/contrib/application/task/test/po/TaskManagerInlinePage.java
+++ b/application-task-test/application-task-test-pageobjects/src/main/java/org/xwiki/contrib/application/task/test/po/TaskManagerInlinePage.java
@@ -19,12 +19,10 @@
  */
 package org.xwiki.contrib.application.task.test.po;
 
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.Select;
 import org.xwiki.test.ui.po.InlinePage;
-import org.xwiki.test.ui.po.SuggestInputElement;
 
 /**
  * Represents a Task entry page being added (inline mode).
@@ -38,7 +36,7 @@ public class TaskManagerInlinePage extends InlinePage
 
     @FindBy(id = CLASS_PREFIX + "name")
     private WebElement nameElement;
-
+    
     @FindBy(id = CLASS_PREFIX + "project")
     private WebElement projectElement;
 
@@ -63,11 +61,6 @@ public class TaskManagerInlinePage extends InlinePage
     @FindBy(id = CLASS_PREFIX + "progress")
     private WebElement progressElement;
 
-    @FindBy(id = "content")
-    private WebElement descriptionElement;
-
-    private SuggestInputElement assigneeSuggestion;
-
     /**
      * @param name the name of the Task entry
      */
@@ -85,7 +78,7 @@ public class TaskManagerInlinePage extends InlinePage
         Select projectSelect = new Select(this.projectElement);
         projectSelect.selectByValue(project);
     }
-
+    
     /**
      * @return The creation date of the task (automatically set)
      */
@@ -99,15 +92,8 @@ public class TaskManagerInlinePage extends InlinePage
      */
     public void setDueDate(String dueDate)
     {
-        this.dueDateElement.click();
         this.dueDateElement.clear();
-        this.dueDateElement.sendKeys(Keys.chord(Keys.CONTROL, "a"));
         this.dueDateElement.sendKeys(dueDate);
-        this.dueDateElement.sendKeys(Keys.ENTER);
-    }
-
-    public void clearDueDate() {
-        this.dueDateElement.clear();
     }
 
     /**
@@ -118,7 +104,7 @@ public class TaskManagerInlinePage extends InlinePage
         Select severitySelect = new Select(this.severityElement);
         severitySelect.selectByValue(severity);
     }
-
+    
     public String getReporter()
     {
         return this.reporterElement.getAttribute("value");
@@ -129,15 +115,8 @@ public class TaskManagerInlinePage extends InlinePage
      */
     public void setAssignee(String assignee)
     {
-        getAssigneeSuggestion().clear().sendKeys(assignee).waitForSuggestions().sendKeys(Keys.ENTER);
-    }
-
-    /**
-     * Clear the value of the assignee field.
-     * @since 3.7.0
-     */
-    public void clearAssignee() {
-        getAssigneeSuggestion().clear();
+        this.assigneeElement.clear();
+        this.assigneeElement.sendKeys(assignee);
     }
 
     /**
@@ -156,35 +135,5 @@ public class TaskManagerInlinePage extends InlinePage
     {
         this.progressElement.clear();
         this.progressElement.sendKeys(progress);
-    }
-
-    /**
-     * @return the text value of the description/content element.
-     * @since 3.7.0
-     */
-    public String getDescription()
-    {
-        return descriptionElement.getText();
-    }
-
-    /**
-     * Clear the description element and set a new value to it.
-     *
-     * @param description the content that will be sent to the element.
-     * @since 3.7.0
-     */
-    public void setDescription(String description)
-    {
-        this.descriptionElement.clear();
-        this.descriptionElement.sendKeys(description);
-    }
-
-    private SuggestInputElement getAssigneeSuggestion()
-    {
-        if (this.assigneeSuggestion != null) {
-            return this.assigneeSuggestion;
-        }
-        this.assigneeSuggestion = new SuggestInputElement(this.assigneeElement);
-        return this.assigneeSuggestion;
     }
 }

--- a/application-task-test/application-task-test-pageobjects/src/main/java/org/xwiki/contrib/application/task/test/po/TaskManagerViewPage.java
+++ b/application-task-test/application-task-test-pageobjects/src/main/java/org/xwiki/contrib/application/task/test/po/TaskManagerViewPage.java
@@ -54,9 +54,6 @@ public class TaskManagerViewPage extends ViewPage
     @FindBy(xpath = "//label[@for=\"" + CLASS_PREFIX + "progress\"]/../../dd/div/div/span")
     private WebElement progressElement;
 
-    @FindBy(xpath = "//label[@for=\"" + CLASS_PREFIX + "description\"]/../../dd/p")
-    private WebElement descriptionElement;
-
     /**
      * Opens the home page.
      */
@@ -91,32 +88,19 @@ public class TaskManagerViewPage extends ViewPage
         return progressElement.getText();
     }
 
-    public String getCreateDate()
-    {
+    public String getCreateDate() {
         return completionDateElement.getText();
     }
 
-    public String getCompletionDate()
-    {
+    public String getCompletionDate() {
         return completionDateElement.getText();
     }
 
-    public String getDueDate()
-    {
+    public String getDueDate() {
         return dueDateElement.getText();
     }
 
-    public String getReporter()
-    {
+    public String getReporter() {
         return reporterElement.getText();
-    }
-
-    /**
-     * @return the description of the task.
-     * @since 3.7.0
-     */
-    public String getDescription()
-    {
-        return descriptionElement.getText();
     }
 }

--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
@@ -146,7 +146,7 @@
                   #set($taskName = $doc.documentReference.parent.name)
                 #end
               #end
-            :   &lt;input class="form-control" type="input" name="TaskManager.TaskManagerClass_0_name" id="TaskManager.TaskManagerClass_0_name" value="$!escapetool.xml($taskName)"/&gt;
+            :   &lt;input class="form-control" type="input" name="TaskManager.TaskManagerClass_0_name" id="TaskManager.TaskManagerClass_0_name" value="$!escapetool.xml($!services.rendering.escape($taskName, 'xwiki/2.1'))"/&gt;
           )))
         )))
         (% class="col-xs-12 col-sm-4 col-md-4" %)

--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
@@ -31,7 +31,7 @@
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
   <version>1.1</version>
-  <title>#if("$!doc.getValue('owner')"!='')#set($name="$!doc.title")#else#set($name="$!doc.getValue('name')")#end#if("$!name"!='')$name#elseif("$!request.title"!='')$request.title#elseif($doc.documentReference.name!='WebHome')$doc.documentReference.name#else$doc.documentReference.parent.name#end</title>
+  <title>#set($name = $!{doc.getObject('TaskManager.TaskManagerClass').getProperty('name').value})#if("$!name" != '')$stringtool.abbreviate($name.trim(), 30)#elseif("$!request.title"!='')$request.title#elseif($doc.documentReference.name != 'WebHome')$doc.documentReference.name#else$doc.documentReference.parent.name#end</title>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
@@ -133,7 +133,6 @@
         (((
           (% class="form-group" %)
           (((
-          #if ("$!doc.getValue('owner')" == '')
             ## Automatically set task name property from the document name
             ; &lt;label for="TaskManager.TaskManagerClass_0_name"&gt;
                 $services.icon.render('book')
@@ -147,13 +146,7 @@
                   #set($taskName = $doc.documentReference.parent.name)
                 #end
               #end
-            :   &lt;input class="form-control" type="input" name="TaskManager.TaskManagerClass_0_name" id="TaskManager.TaskManagerClass_0_name" value="$!escapetool.xml($!services.rendering.escape($taskName, 'xwiki/2.1'))"/&gt;
-          #else
-            ; &lt;label for="xwikidoctitleinput"&gt;
-                $escapetool.xml($services.localization.render('core.editors.content.titleField.label'))
-              &lt;/label&gt;
-            : &lt;input type="text" id="xwikidoctitleinput" name="title" value="$!escapetool.xml($!services.rendering.escape($!doc.title, 'xwiki/2.1'))" /&gt;
-          #end
+            :   &lt;input class="form-control" type="input" name="TaskManager.TaskManagerClass_0_name" id="TaskManager.TaskManagerClass_0_name" value="$!escapetool.xml($taskName)"/&gt;
           )))
         )))
         (% class="col-xs-12 col-sm-4 col-md-4" %)

--- a/application-task-ui/src/main/resources/TaskManager/TaskReportResultPage.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskReportResultPage.xml
@@ -70,7 +70,7 @@
     #if ("$!row.number" == '')
       #set ($row.name = $services.localization.render('taskmanager.livetable.noRights'))
     #else
-      #set ($row.name = $doc.getRenderedContentRestricted("{{tasks ids='${row.number}'/}}", $doc.syntax))
+      #set ($row.name = $doc.getRenderedContent("{{tasks ids='${row.number}'/}}", $doc.syntax))
     #end
   #end
   #jsonResponse($map)


### PR DESCRIPTION
Revert PR #179 that fixed #81 and several other issues.

The solution pushed for #81 was to store the content of the task macro in the name property of the task object. This caused caused various other macros and functionalities, that are part of the Task App, to display tasks containing xwiki syntax. This led to a discussion on how should we handle the todo style tasks vs the jira-like tasks. We need to handle this in a separate issue. See #197 