### PR TITLE
Add the possibility to define a task description template #94

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/CreateTaskTemplateEndpoint.xml
+++ b/application-task-ui/src/main/resources/TaskManager/CreateTaskTemplateEndpoint.xml
@@ -1,0 +1,99 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.5" reference="TaskManager.CreateTaskTemplateEndpoint" locale="">
+  <web>TaskManager</web>
+  <name>CreateTaskTemplateEndpoint</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>TaskManager.TaskTemplateList</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>CreateTaskTemplateEndpoint</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity wiki="false"}}
+#if($xcontext.action == 'get')
+  #set ($discard = $response.setContentType('application/json'))
+  ## Get template and provider names
+  #set ($templateName = $request.templateName)
+  #if ("$!templateName" != '')
+    #set ($templateDoc = $xwiki.getDocument("TaskManager.TaskManagerTemplates.$!{templateName}Template"))
+    #set ($providerDoc = $xwiki.getDocument("TaskManager.TaskManagerTemplates.$!{templateName}TemplateProvider"))
+    #set ($templateExists = $xwiki.exists($templateDoc.getDocumentReference()))
+    #set ($providerExists = $xwiki.exists($providerDoc.getDocumentReference()))
+    #set ($responseJSON = {
+      'templateDocument': {'reference': "$templateDoc", 'exists': $templateExists},
+      'providerDocument': {'reference': "$providerDoc", 'exists': $providerExists}
+    })
+    #if ($providerExists)
+      $response.setStatus(409)
+      $jsontool.serialize($responseJSON)
+    #elseif ($templateDoc.hasAccessLevel('edit') &amp;&amp; $providerDoc.hasAccessLevel('edit'))
+      #if (!$templateExists)
+        #set ($discard = $templateDoc.createNewObject('TaskManager.TaskManagerClass'))
+        #set ($discard = $templateDoc.setHidden(true))
+        #set ($discard = $templateDoc.save('Create template', true))
+      #end
+      ## If provider doesn't exist, copy the base provider and configure it
+      #if (!$providerExists)
+        #if ($xwiki.exists('TaskManager.TaskManagerTemplateProvider'))
+          #set ($discard = $xwiki.copyDocument(
+            $xwiki.getDocument('TaskManager.TaskManagerTemplateProvider').getDocumentReference(),
+            $providerDoc.getDocumentReference(),
+            null, true, false
+          ))
+        #else
+          #set ($discard = $responseJSON.get('providerDocument').put('exists', 'noProvider'))
+        #end
+        #set ($providerObj = $providerDoc.getObject('XWiki.TemplateProviderClass'))
+        #set ($discard = $providerDoc.setHidden(true))
+        #if ("$!providerObj" == '')
+          #set ($discard = $providerDoc.createNewObject('XWiki.TemplateProviderClass'))
+          #set ($providerObj = $providerDoc.getObject('XWiki.TemplateProviderClass'))
+          ## Hardcoded defaults
+          #set ($discard = $providerObj.set('action', 'Edit'))
+          #set ($discard = $providerObj.set('terminal', 1))
+          #set ($discard = $providerObj.set('icon', 'application_view_list'))
+          #set ($discard = $providerObj.set('creationRestrictions', 'TaskManager'))
+          #set ($discard = $providerObj.set('creationRestrictionsAsSuggestions', 0))
+        #end
+        #set ($discard = $providerObj.set('name', $templateName))
+        #set ($discard = $providerObj.set('template', $templateDoc.getFullName()))
+        #set ($discard = $providerDoc.save('Create template provider', true))
+      #end
+      #set ($discard = $response.setStatus(200))
+      $jsontool.serialize($responseJSON)
+    #else
+      #set ($discard = $response.setStatus(401))
+    #end
+  #else
+    #set ($discard = $response.setStatus(400))
+  #end
+#end
+{{/velocity}}</content>
+</xwikidoc>

--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerLiveTableResults.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerLiveTableResults.xml
@@ -36,5 +36,34 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{include reference="XWiki.LiveTableResults" /}}</content>
+  <content>{{include reference="XWiki.LiveTableResultsMacros" /}}
+
+{{velocity wiki="false"}}
+## the $extra variable is passed to the call to #gridresultwithfilter below and is used to perform some default
+## filtering on the LiveTable data even when the user has not performed any column filtering yet.
+## When users start using column filtering, the generated DB query will combine both the default filtering and what the
+## user has entered in the column filters.
+#set ($extra = "and doc.fullName not like '%Template'")
+#set ($params = {})
+#if ("$!request.space" != '')
+#set ($extra = "${extra} AND doc.space = :doc_space")
+#set ($discard = $params.put('doc_space', $request.space))
+#end
+## Use filterLocation since addLivetableLocationFilter is buggy when called several times (it'll add the
+## same HQL binding name every time it's called! See https://jira.xwiki.org/browse/XWIKI-17463).
+## Also note that we don't call addLocationFilter since we use a Map for $params.
+#filterLocation($extra, $params, $!request.location, 'locationFilterValue1')
+#if ("$!request.parent" != '')
+#set ($extra = "${extra} and doc.parent = :doc_parent")
+#set ($discard = $params.put('doc_parent', $request.parent))
+#end
+#if ("$!request.orphaned" == '1')
+#set ($homepage = $services.wiki.getById($services.wiki.currentWikiId).mainPageReference)
+#set ($homepageFullName = $services.model.serialize($homepage, 'local'))
+## On Oracle the empty parent is actually null.
+#set ($extra = "${extra} and (doc.parent = '' or doc.parent is null) and doc.fullName &lt;&gt; :homepageFullName")
+#set ($discard = $params.put('homepageFullName', $homepageFullName))
+#end
+#gridresultwithfilter("$!request.classname" $request.collist.split(',') '' "${extra}" $params)
+{{/velocity}}</content>
 </xwikidoc>

--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerSheet.xml
@@ -148,6 +148,10 @@
                   ## we are a non-terminal page: use space name
                   #set($taskName = $doc.documentReference.parent.name)
                 #end
+                #if ($taskName.endsWith('Template'))
+                  ## Don't set the title for templates.
+                  #set ($taskName = '')
+                #end
               #end
             :   &lt;input class="form-control" type="input" name="TaskManager.TaskManagerClass_0_name" id="TaskManager.TaskManagerClass_0_name" value="$!escapetool.xml($!services.rendering.escape($taskName, 'xwiki/2.1'))"/&gt;
           )))

--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerTranslations.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerTranslations.xml
@@ -105,6 +105,17 @@ taskmanager.livetable._actions.edit=Edit
 taskmanager.livetable._actions.delete=Delete
 taskmanager.livetable.emptyvalue=-
 
+# Template list specific keys
+taskmanager.templateList.label=Template name
+taskmanager.templateList.button=Create new template
+taskmanager.templateList.livetable.taskName=Template task page
+taskmanager.templateList.livetable.providerName=Template provider name
+taskmanager.templateList.notification.inprogress=Creating template
+taskmanager.templateList.notification.done=Template created
+taskmanager.templateList.notification.fail=Could not create template
+taskmanager.templateList.notification.fail.conflict=Template already exists
+taskmanager.templateList.notification.fail.unauthorized=Unauthorized
+
 # Live table specific keys
 taskmanager.livetable.name=Task
 taskmanager.livetable.number=Key

--- a/application-task-ui/src/main/resources/TaskManager/TaskTemplateList.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskTemplateList.xml
@@ -1,0 +1,210 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.5" reference="TaskManager.TaskTemplateList" locale="">
+  <web>TaskManager</web>
+  <name>TaskTemplateList</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>TaskManager.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>Create Task Template</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity}}
+{{html}}
+&lt;form&gt;
+&lt;input name='outputSyntax' type='hidden' value='plain'&gt;
+&lt;label for='templateName'&gt;$escapetool.xml($services.localization.render('taskmanager.templateList.label'))&lt;/label&gt;
+&lt;input name='templateName' type='text' required&gt;&lt;/input&gt;
+&lt;button id='button-submit-template' class='btn btn-primary'&gt;$escapetool.xml($services.localization.render('taskmanager.templateList.button'))&lt;/button&gt;
+&lt;/form&gt;
+{{/html}}
+
+#set ($columnsProperties = {
+  'name' : { 'link' : 'view', 'displayName' : $escapetool.xml($services.localization.render('taskmanager.templateList.livetable.providerName')) },
+  'description' : {},
+  'template' : { 'html' : 'true', 'displayName' : $escapetool.xml($services.localization.render('taskmanager.templateList.livetable.taskName')) },
+  'doc.date'  : { 'type' : 'date' },
+  'doc.author' : { 'link' : 'author' },
+  '_actions': {'actions': ['edit','delete']}
+})
+#set ($options = {
+  'tagCloud': true,
+  'className': 'XWiki.TemplateProviderClass',
+  'translationPrefix': 'taskmanager.livetable.',
+  'resultPage': 'TaskManager.TaskTemplateListLivetableResults',
+  'queryFilters': 'currentlanguage,unique'
+})
+#set ($columns = ['name', 'description', 'template', 'doc.date', 'doc.author', '_actions'])
+#livetable('taskmanagerTemplateList' $columns $columnsProperties $options)
+{{/velocity}}</content>
+  <object>
+    <name>TaskManager.TaskTemplateList</name>
+    <number>0</number>
+    <className>XWiki.JavaScriptExtension</className>
+    <guid>9c7f0864-1432-4746-a23b-1827ae0b8761</guid>
+    <class>
+      <name>XWiki.JavaScriptExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <defaultValue>long</defaultValue>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <restricted>0</restricted>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property>
+      <cache>forbid</cache>
+    </property>
+    <property>
+      <code>define('xwiki-task-template-list-notification-messages', {
+  prefix: 'taskmanager.templateList.notification.',
+  keys: [
+    'inprogress',
+    'done',
+    'fail',
+    'fail.conflict',
+    'fail.unauthorized',
+  ]
+});
+require(['jquery', 'xwiki-l10n!xwiki-task-template-list-notification-messages'], function ($, l10n) {
+  var escapeHTML = function(text) {
+    let textHTMLEscape = new Element('span');
+    textHTMLEscape.textContent = text;
+    return textHTMLEscape.innerHTML;
+  };
+  console.log(l10n)
+  $(document).on('click', '#button-submit-template', function (event) {
+    const endpointURL = new XWiki.Document(
+        XWiki.Model.resolve('TaskManager.CreateTaskTemplateEndpoint', XWiki.EntityType.DOCUMENT)
+    ).getURL('get');
+    event.preventDefault();
+    console.log('ahh');
+    // Check that the template name is not empty.
+    if (event.target.parentElement.reportValidity()) {
+      let notification = new XWiki.widgets.Notification(escapeHTML(l10n.get('inprogress')), 'inprogress');
+      $.ajax(endpointURL + '?' + event.target.parentElement.serialize()).done((data) =&gt; {
+        notification.replace(new XWiki.widgets.Notification(escapeHTML(l10n.get('done')), 'done'));
+        document.location = new XWiki.Document(
+            XWiki.Model.resolve(data.templateDocument.reference, XWiki.EntityType.DOCUMENT)
+        ).getURL('edit');
+      }).fail((data) =&gt; {
+        console.log(data)
+        let reason = l10n.get('fail');
+        if (data.status === 401) {
+            reason = l10n.get('fail.unauthorized');
+        } else if (data.status === 409) {
+            reason = l10n.get('fail.conflict');
+        }
+        notification.replace(new XWiki.widgets.Notification(escapeHTML(reason), 'error'));
+      });
+    }
+  })
+});</code>
+    </property>
+    <property>
+      <name/>
+    </property>
+    <property>
+      <parse>0</parse>
+    </property>
+    <property>
+      <use>currentPage</use>
+    </property>
+  </object>
+</xwikidoc>

--- a/application-task-ui/src/main/resources/TaskManager/TaskTemplateListLivetableResults.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskTemplateListLivetableResults.xml
@@ -1,0 +1,45 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.5" reference="TaskManager.TaskTemplateListLivetableResults" locale="">
+  <web>TaskManager</web>
+  <name>TaskTemplateListLivetableResults</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>TaskTemplateListLivetableResults</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{include reference="XWiki.LiveTableResultsMacros" /}}
+
+{{velocity wiki="false"}}
+#gridresultwithfilter('XWiki.TemplateProviderClass', $request.collist.split(','), ", BaseObject templateProviderObj, StringProperty templateProp, BaseObject taskObj", " AND templateProviderObj.name = doc.fullName AND templateProp.id = templateProviderObj.id.id AND templateProp.id.name='template' AND templateProp.value = taskObj.name AND taskObj.className = 'TaskManager.TaskManagerClass'")
+{{/velocity}}
+</content>
+</xwikidoc>


### PR DESCRIPTION
Added hidden Task Template List page, to make creating task templates easier. The templates have full control over description, title, status and all other task properties, along with tags or custom objects.


Workflow:
1. Add template name and click `Create new task`
2. A template provider is created (copy of the default TaskManagerTemplateProvider), along with a template task (if one doesn't exist already)
3. User is redirected to the template task to edit it
4. If more customization is needed, both created pages are accessible in the Task Template List livetable

![image](https://github.com/user-attachments/assets/ecd2a8da-be78-4985-86ad-a3b2bd12dc6c)
