### PR TITLE
Task card macro - Choose a task stored in a sub_hierachy with special character in its name displays a broken link #217

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/TaskCardMacro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskCardMacro.xml
@@ -570,7 +570,7 @@
   #if(!$tasktitle.trim().isEmpty())
     (% class="col-xs-12 task-card-title" %)
     (((
-      [[${tasktitle}&gt;&gt;${tasklink}]]
+      [[$services.rendering.escape($tasktitle,'xwiki/2.1')&gt;&gt;$services.rendering.escape($tasklink,'xwiki/2.1')]]
     )))
   #end
 #end


### PR DESCRIPTION
* Updated the code to properly escape the link&title of the task in a card macro.
![image](https://github.com/user-attachments/assets/ec314514-d1f8-4e2c-8d91-725493679d54)
