### PR TITLE
Problems creating new tasks on a page with migrated tasks #226

### DIFF
--- a/application-task-default/src/main/java/com/xwiki/task/internal/DefaultTaskReferenceGenerator.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/DefaultTaskReferenceGenerator.java
@@ -64,15 +64,29 @@ public class DefaultTaskReferenceGenerator implements TaskReferenceGenerator
     private DocumentReference getUniqueName(SpaceReference spaceRef) throws Exception
     {
 
-        int i = nameOccurences.getOrDefault(spaceRef, 0);
-        DocumentReference docRef = new DocumentReference(TASK_PAGE_NAME_PREFIX + i, spaceRef);
+        int i = nameOccurences.getOrDefault(spaceRef, 1);
+        String pageName = TASK_PAGE_NAME_PREFIX + i;
+        DocumentReference docRef = composeDocReference(pageName, spaceRef, false);
+        DocumentReference nonTerminalDocRef = composeDocReference(pageName, spaceRef, true);
 
-        while (documentAccessBridge.exists(docRef)) {
+        while (documentAccessBridge.exists(docRef) || documentAccessBridge.exists(nonTerminalDocRef)) {
             i++;
-            docRef = new DocumentReference(TASK_PAGE_NAME_PREFIX + i, spaceRef);
+            pageName = TASK_PAGE_NAME_PREFIX + i;
+            docRef = composeDocReference(pageName, spaceRef, false);
+            nonTerminalDocRef = composeDocReference(pageName, spaceRef, true);
             nameOccurences.put(spaceRef, i);
         }
         nameOccurences.put(spaceRef, ++i);
         return docRef;
+    }
+
+    private DocumentReference composeDocReference(String pageRef, SpaceReference spaceReference, boolean terminal)
+    {
+        if (!terminal) {
+            return new DocumentReference(pageRef, spaceReference);
+        } else {
+            SpaceReference spRef = new SpaceReference(pageRef, spaceReference);
+            return new DocumentReference("WebHome", spRef);
+        }
     }
 }

--- a/application-task-default/src/test/java/com/xwiki/task/DefaultTaskReferenceGeneratorTest.java
+++ b/application-task-default/src/test/java/com/xwiki/task/DefaultTaskReferenceGeneratorTest.java
@@ -74,10 +74,10 @@ class DefaultTaskReferenceGeneratorTest
         when(this.documentAccessBridge.exists(any(DocumentReference.class))).thenReturn(false);
 
         DocumentReference generatedReference = this.referenceGenerator.generate(documentReference);
-        assertEquals(new DocumentReference("Task_0", documentReference.getLastSpaceReference()), generatedReference);
+        assertEquals(new DocumentReference("Task_1", documentReference.getLastSpaceReference()), generatedReference);
 
         DocumentReference generatedReference1 = this.referenceGenerator.generate(documentReference);
-        assertEquals(new DocumentReference("Task_1", documentReference.getLastSpaceReference()), generatedReference1);
+        assertEquals(new DocumentReference("Task_2", documentReference.getLastSpaceReference()), generatedReference1);
     }
 
     @Test
@@ -85,12 +85,12 @@ class DefaultTaskReferenceGeneratorTest
     {
         when(this.documentAccessBridge.exists(any(DocumentReference.class))).thenReturn(false);
         when(
-            this.documentAccessBridge.exists(new DocumentReference("Task_0", documentReference.getLastSpaceReference()))
+            this.documentAccessBridge.exists(new DocumentReference("Task_1", documentReference.getLastSpaceReference()))
         ).thenReturn(true);
 
         DocumentReference generatedReference = this.referenceGenerator.generate(documentReference);
 
-        assertEquals(new DocumentReference("Task_1", documentReference.getLastSpaceReference()),
+        assertEquals(new DocumentReference("Task_2", documentReference.getLastSpaceReference()),
             generatedReference);
     }
 }


### PR DESCRIPTION
* Update the code to also check for non-terminal pages
* Updated the task to start from 1 instead of 0 -> This change is made to ensure consistency with confluence, where task ids start at 1. When migrating a page from confluence that already has, for example, 3 tasks, a new task currently gets the id 0, resulting in ids like 0, 4, 5, and so on. By starting from 1 instead the new task would directly get the id 4. I also believe it's more intuitive to start from 1 since most people count from 1. I’ve already discussed this with Teo, and he agreed with the change.