### PR TITLE
Bottom padding missing in Task card #190

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/TaskCardMacro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskCardMacro.xml
@@ -172,6 +172,8 @@
   border-style: solid;
   border-width: 1px;
   border-color: ${xwikibordercolor};
+  padding-top: 1ex;
+  padding-bottom: 1ex;
 }
 .task-card .task-card-title {
   color: #2173AF;
@@ -193,6 +195,7 @@
   border-width: 8px;
   padding: 0;
   margin: 0;
+  top: 0;
   left: 0;
   z-index: 5;
 }
@@ -637,13 +640,15 @@
       ${services.localization.render('TaskManager.TaskManagerClass_status_Late')}
     )))
   #end
-  #if($xcontext.macro.params.dependencies == 'true')
+  #if($xcontext.macro.params.dependencies == 'true' &amp;&amp; $taskdependencies.size() &gt; 0)
     #displayCardDependencies($taskdependencies)
   #end
   #displayCardStatus($taskstatus)
   #displayCardTitle($tasktitle, $tasklink)
   #displayCardDueDate($taskduedate)
-  #displayCardAssignee($taskassignee)
+  #if ("$!taskassignee" != '')
+    #displayCardAssignee($taskassignee)
+  #end
 )))
 {{/velocity}}
 </code>


### PR DESCRIPTION
* Added padding
* Hide dependencies and user picture if empty, so they don't look like extra padding

|Before (Task Manager 3.7.2)|After|
|---|---|
|![image](https://github.com/user-attachments/assets/6aa7e4be-2818-4267-968b-d5a500bf3549)|![image](https://github.com/user-attachments/assets/e11dbc84-6c9a-4814-9543-4017b8c8c1e2)|