### PR TITLE
Rename taskbox macro to checkbox #261

### DIFF
--- a/application-task-api/src/main/java/com/xwiki/task/TaskboxId.java
+++ b/application-task-api/src/main/java/com/xwiki/task/TaskboxId.java
@@ -23,7 +23,7 @@ package com.xwiki.task;
 import org.xwiki.stability.Unstable;
 
 /**
- * Identifies the ID of the taskbox macro.
+ * Identifies the ID of the checkbox macro.
  *
  * @version $Id$
  * @since 3.8.0

--- a/application-task-api/src/main/java/com/xwiki/task/macro/TaskboxMacroParameters.java
+++ b/application-task-api/src/main/java/com/xwiki/task/macro/TaskboxMacroParameters.java
@@ -26,7 +26,7 @@ import org.xwiki.properties.annotation.PropertyMandatory;
 import com.xwiki.task.TaskboxId;
 
 /**
- * The parameters used by the taskbox macro.
+ * The parameters used by the checkbox macro.
  *
  * @version $Id$
  * @since 3.8.0

--- a/application-task-api/src/main/resources/templates/html_displayer/taskboxid/edit.vm
+++ b/application-task-api/src/main/resources/templates/html_displayer/taskboxid/edit.vm
@@ -17,7 +17,7 @@
 ## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 ## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 ## ---------------------------------------------------------------------------
-#set ($discard = $xwiki.jsx.use('TaskManager.TaskboxInit'))
+#set ($discard = $xwiki.jsx.use('TaskManager.CheckboxInit'))
 <input
   class="taskbox-id"
   type="text"

--- a/application-task-default/src/main/java/com/xwiki/task/internal/macro/TaskboxMacro.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/macro/TaskboxMacro.java
@@ -50,7 +50,7 @@ import com.xwiki.task.model.Task;
  * @since 3.8.0
  */
 @Component
-@Named("taskbox")
+@Named("checkbox")
 @Singleton
 public class TaskboxMacro extends AbstractMacro<TaskboxMacroParameters>
 {

--- a/application-task-default/src/main/java/com/xwiki/task/internal/rest/DefaultTaskboxResource.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/rest/DefaultTaskboxResource.java
@@ -45,7 +45,7 @@ import com.xwiki.task.rest.TaskboxResource;
 
 /**
  * The default implementation for the {@link TaskboxResource} that recursively looks through the content of a given page
- * and the content of its macros, finds the taskbox macro, updates the status and saves the page.
+ * and the content of its macros, finds the checkbox macro, updates the status and saves the page.
  *
  * @version $Id$
  * @since 3.8.0
@@ -96,7 +96,7 @@ public class DefaultTaskboxResource extends XWikiResource implements TaskboxReso
             try {
                 document.setContent(docDOM);
                 context.getWiki()
-                    .saveDocument(document, String.format("Updated the taskbox with id [%s].", id), context);
+                    .saveDocument(document, String.format("Updated the checkbox with id [%s].", id), context);
                 return Response.ok().build();
             } catch (XWikiException e) {
                 throw new XWikiRestException("Failed to update the content of the page.", e);
@@ -111,7 +111,7 @@ public class DefaultTaskboxResource extends XWikiResource implements TaskboxReso
     {
         AtomicReference<Boolean> contentChanged = new AtomicReference<>(false);
         XDOM updatedXDOM = macroBlockFinder.find(docDOM, document.getSyntax(), (macroBlock -> {
-            if (!"taskbox".equals(macroBlock.getId())) {
+            if (!"checkbox".equals(macroBlock.getId())) {
                 return MacroBlockFinder.Lookup.CONTINUE;
             }
             String macroId = macroBlock.getParameters().getOrDefault("id", "");

--- a/application-task-default/src/test/resources/taskbox1.test
+++ b/application-task-default/src/test/resources/taskbox1.test
@@ -3,14 +3,14 @@
 .input|xwiki/2.0
 .# Task macro test without displaying the id.
 .#-----------------------------------------------------
-{{taskbox id="Sandbox.Task" checked="true" }}
+{{checkbox id="Sandbox.Task" checked="true" }}
 Important task with the following deadline
-{{/taskbox}}
+{{/checkbox}}
 .#-----------------------------------------------------
 .expect|event/1.0
 .#-----------------------------------------------------
 beginDocument
-beginMacroMarkerStandalone [taskbox] [id=Sandbox.Task|checked=true] [Important task with the following deadline]
+beginMacroMarkerStandalone [checkbox] [id=Sandbox.Task|checked=true] [Important task with the following deadline]
 beginMacroMarkerStandalone [task] [reference=Sandbox.Task|idDisplayed=FALSE|className=taskbox|status=Done] [Important task with the following deadline]
 beginGroup [[class]=[task-macro taskbox]]
 beginGroup [[class]=[task-info]]
@@ -37,7 +37,7 @@ endMetaData [[non-generated-content]=[java.util.List<org.xwiki.rendering.block.B
 endGroup [[class]=[task-content]]
 endGroup [[class]=[task-macro taskbox]]
 endMacroMarkerStandalone [task] [reference=Sandbox.Task|idDisplayed=FALSE|className=taskbox|status=Done] [Important task with the following deadline]
-endMacroMarkerStandalone [taskbox] [id=Sandbox.Task|checked=true] [Important task with the following deadline]
+endMacroMarkerStandalone [checkbox] [id=Sandbox.Task|checked=true] [Important task with the following deadline]
 endDocument
 .#-----------------------------------------------------
 .expect|xhtml/1.0

--- a/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
+++ b/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
@@ -283,18 +283,18 @@ class TaskManagerIT
     @ParameterizedTest
     @WikisSource()
     @Order(9)
-    void taskboxMacro(WikiReference wiki, TestUtils setup,
+    void checkboxMacro(WikiReference wiki, TestUtils setup,
         TestLocalReference testLocalReference, TestReference testReference)
     {
         DocumentReference testRef = new DocumentReference(docWithTaskboxes, wiki);
-        setup.createPage(testRef, "{{taskbox id=\"someId\"}}Hello there{{/taskbox}}");
+        setup.createPage(testRef, "{{checkbox id=\"someId\"}}Hello there{{/checkbox}}");
         ViewPageWithTasks viewPageWithTasks = new ViewPageWithTasks();
         assertEquals("Hello there", viewPageWithTasks.getTaskMacroContent(0));
         assertEquals(false, viewPageWithTasks.isTaskMacroCheckboxChecked(0));
         viewPageWithTasks.clickTaskMacroCheckbox(0);
 
         WikiEditPage editPage = viewPageWithTasks.editWiki();
-        assertEquals("{{taskbox id=\"someId\" checked=\"true\"}}\nHello there\n{{/taskbox}}", editPage.getContent());
+        assertEquals("{{checkbox id=\"someId\" checked=\"true\"}}\nHello there\n{{/checkbox}}", editPage.getContent());
         editPage.clickSaveAndView(true);
         viewPageWithTasks = new ViewPageWithTasks();
         assertEquals(true, viewPageWithTasks.isTaskMacroCheckboxChecked(0));

--- a/application-task-ui/src/main/resources/TaskManager/CheckboxInit.xml
+++ b/application-task-ui/src/main/resources/TaskManager/CheckboxInit.xml
@@ -20,9 +20,9 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.5" reference="TaskManager.TaskboxInit" locale="">
+<xwikidoc version="1.5" reference="TaskManager.CheckboxInit" locale="">
   <web>TaskManager</web>
-  <name>TaskboxInit</name>
+  <name>CheckboxInit</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
@@ -31,14 +31,14 @@
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
   <version>1.1</version>
-  <title>TaskboxInit</title>
+  <title>CheckboxInit</title>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content/>
   <object>
-    <name>TaskManager.TaskboxInit</name>
+    <name>TaskManager.CheckboxInit</name>
     <number>0</number>
     <className>XWiki.JavaScriptExtension</className>
     <guid>cd788882-1c6e-4cda-96a6-acd6f69123b8</guid>

--- a/application-task-ui/src/main/resources/TaskManager/TaskManagerTranslations.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskManagerTranslations.xml
@@ -230,13 +230,13 @@ rendering.macro.task.parameter.completeDate.description=If you set the status of
 rendering.macro.task.parameter.idDisplayed.name=Is ID Displayed?
 rendering.macro.task.parameter.idDisplayed.description=Denotes whether the id and the link to the task page should be displayed.
 
-rendering.macro.taskbox.name=Taskbox
-rendering.macro.taskbox.description=Display a simple checkbox alongside some rich content.
-rendering.macro.taskbox.content.description=Rich content that describes this to-do item.
-rendering.macro.taskbox.parameter.id.name=Id
-rendering.macro.taskbox.parameter.id.description=Uniquely identifies the taskbox on the current page. It is recommended to use the autofilled value.
-rendering.macro.taskbox.parameter.checked.name=Checked?
-rendering.macro.taskbox.parameter.checked.description=Denotes whether the checkbox is ticked or not.
+rendering.macro.checkbox.name=Checkbox
+rendering.macro.checkbox.description=Display a simple checkbox alongside some rich content.
+rendering.macro.checkbox.content.description=Rich content that describes this to-do item.
+rendering.macro.checkbox.parameter.id.name=Id
+rendering.macro.checkbox.parameter.id.description=Uniquely identifies the checkbox on the current page. It is recommended to use the autofilled value.
+rendering.macro.checkbox.parameter.checked.name=Checked?
+rendering.macro.checkbox.parameter.checked.description=Denotes whether the checkbox is ticked or not.
 
 rendering.macro.task-report.name=Task report macro
 rendering.macro.task-report.description=Create a custom report of the tasks within the wiki.


### PR DESCRIPTION
* Rename the front-facing mentions of the taskbox macro to `checkbox`