### PR TITLE
Author of task macro is not properly recorded #266

### DIFF
--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskMacroUpdateEventListener.java
@@ -245,6 +245,7 @@ public class TaskMacroUpdateEventListener extends AbstractTaskEventListener
         BaseObject clonedObj = taskObj.clone();
         UserReference currentUser = userRefResolver.resolve(context.getUserReference());
         taskDoc.getAuthors().setEffectiveMetadataAuthor(currentUser);
+        taskDoc.getAuthors().setOriginalMetadataAuthor(currentUser);
         clonedObj.set(Task.OWNER, serializer.serialize(document.getDocumentReference(), taskReference),
             context);
         populateObjectWithMacroParams(context, task, clonedObj);

--- a/application-task-default/src/main/java/com/xwiki/task/internal/TaskObjectUpdateEventListener.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/TaskObjectUpdateEventListener.java
@@ -39,6 +39,8 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.observation.event.Event;
+import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceResolver;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -64,6 +66,10 @@ public class TaskObjectUpdateEventListener extends AbstractTaskEventListener
 
     @Inject
     private TaskCounter taskCounter;
+
+    @Inject
+    @Named("document")
+    private UserReferenceResolver<DocumentReference> userRefResolver;
 
     /**
      * Constructor.
@@ -115,6 +121,8 @@ public class TaskObjectUpdateEventListener extends AbstractTaskEventListener
                     ownerDocument.setContent(
                         taskXDOMProcessor.updateTaskMacroCall(taskOwnerRef, taskObj, ownerDocument.getXDOM(),
                             ownerDocument.getSyntax()));
+                    UserReference currentUserReference = userRefResolver.resolve(context.getUserReference());
+                    ownerDocument.getAuthors().setOriginalMetadataAuthor(currentUserReference);
                     context.getWiki().saveDocument(ownerDocument,
                         String.format("Task [%s] has been updated!", taskObj.getDocumentReference()), context);
                 }

--- a/application-task-default/src/main/java/com/xwiki/task/internal/rest/DefaultTaskResource.java
+++ b/application-task-default/src/main/java/com/xwiki/task/internal/rest/DefaultTaskResource.java
@@ -35,6 +35,8 @@ import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.internal.resources.pages.ModifiablePageResource;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
+import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceResolver;
 
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
@@ -61,6 +63,10 @@ public class DefaultTaskResource extends ModifiablePageResource implements TaskR
     private ContextualAuthorizationManager contextualAuthorizationManager;
 
     @Inject
+    @Named("document")
+    private UserReferenceResolver<DocumentReference> userRefResolver;
+
+    @Inject
     private TaskConfiguration taskConfiguration;
 
     @Override
@@ -75,6 +81,8 @@ public class DefaultTaskResource extends ModifiablePageResource implements TaskR
 
         try {
             XWikiDocument document = getXWikiContext().getWiki().getDocument(docRef, getXWikiContext()).clone();
+            UserReference currentUserReference = userRefResolver.resolve(getXWikiContext().getUserReference());
+            document.getAuthors().setOriginalMetadataAuthor(currentUserReference);
             BaseObject taskObject = document.getXObject(TASK_CLASS_REFERENCE);
 
             if (taskObject == null) {

--- a/application-task-default/src/test/java/com/xwiki/task/TaskMacroUpdateEventListenerTest.java
+++ b/application-task-default/src/test/java/com/xwiki/task/TaskMacroUpdateEventListenerTest.java
@@ -231,6 +231,7 @@ class TaskMacroUpdateEventListenerTest
 
         verify(this.taskObj).set(Task.OWNER, this.pageWithMacro.toString(), this.context);
         verify(this.documentAuthors).setEffectiveMetadataAuthor(this.userRef);
+        verify(this.documentAuthors).setOriginalMetadataAuthor(this.userRef);
         verify(this.taskObj).set(Task.NAME, "Hello there", this.context);
         verify(this.wiki).saveDocument(this.taskDoc, "Task updated!", this.context);
         verify(this.wiki).deleteDocument(this.task_1Doc, this.context);


### PR DESCRIPTION
* Set the original metadata author in the task listeners (it is the one shown in the UI)