### PR TITLE
Fix for #302: Parallel filters in task report macro

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/TaskReportMacro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskReportMacro.xml
@@ -369,7 +369,7 @@
 #end
 #if (!$creatorFilter.isEmpty())
   #set ($discard = $livedataCfg['query']['filters'].add({
-    'property': 'creator',
+    'property': 'reporter',
     'matchAll': false,
     'constraints': $creatorFilter
 }))


### PR DESCRIPTION
Filters for status and creator columns in task report macro are now passed in inline metadata instead of livedata filter parameter to allow parallel filtering to work.