### PR TITLE
Cannot perform inline editing on pages differ to task ones #309

### DIFF
--- a/application-task-ui/pom.xml
+++ b/application-task-ui/pom.xml
@@ -38,7 +38,8 @@
     <!-- The list of documents that have an implicit unlimited free license. The users can view these documents without
       buying a license or getting a trial license, but they cannot edit or delete them. -->
     <xwiki.extension.licensing.publicDocuments>
-      TaskManager.WebHome
+      TaskManager.WebHome,
+      TaskManager.CKEditorPlugin.PluginEnabler
     </xwiki.extension.licensing.publicDocuments>
     <xwiki.extension.licensing.excludedDocuments>
       TaskManager.Administration,


### PR DESCRIPTION
Added the CKEditor plugin page to the public licensed documents. Now all users should be able to see the page, but be unable to edit it.