### PR TITLE
Task id parameter in task card macro shows "WebHome" for tasks created using the task macro

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/TaskPagesSearch.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskPagesSearch.xml
@@ -37,15 +37,26 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity output="false"}}
-#if($xcontext.action == 'get' &amp;&amp; "$!{request.outputSyntax}" == 'plain')
+#if ($xcontext.action == 'get' &amp;&amp; "$!{request.outputSyntax}" == 'plain')
   #set ($statement = "FROM doc.object(TaskManager.TaskManagerClass) AS taskObject WHERE doc.space &lt;&gt; 'TaskManager.TaskManagerTemplates' AND lower(doc.fullName) LIKE lower(:param)")
   #set ($param = $services.query.parameter().anyChars().literal("$!request.text").anyChars())
   #set ($query = $services.query.xwql($statement).addFilter('unique').addFilter('document').setLimit(10).bindValue('param', $param))
   #set ($array = [])
   #foreach ($taskReference in $query.execute())
     #if ($services.security.authorization.hasAccess("view", $taskReference))
+      #set ($taskDoc = $xwiki.getDocument($taskReference))
+      #set ($taskObj = $taskDoc.getObject('TaskManager.TaskManagerClass'))
+      #set ($taskTitle = '')
+      #if ($taskObj)
+        #set ($taskTitle = "$!taskObj.getProperty('name').value.trim()")
+      #end
+      #if ($taskTitle != '')
+        #set ($label = $taskTitle)
+      #else
+        #set ($label = $taskReference.name)
+      #end
       #set ($discard = $array.add({
-        'label': $taskReference.name,
+        'label': $label,
         'value': $services.model.serialize($taskReference, 'compactwiki'),
         'hint':  $services.model.serialize($taskReference.parent, 'compactwiki')
       }))


### PR DESCRIPTION
I'm retrieving from document an object of `TaskManager.TaskManagerClass`, and if task has such object then setting the label as property value. Otherwise, the name of the task will be used. During additional tests, I notified that this fix perfectly works if such condition is met: created task via macro or quick actions has at least name. But this low probability can be dismissed, I doubt as a user creating empty tasks from macros or commands in the end.

### Before PR:

<img width="750" height="455" alt="Знімок екрана з 2026-02-26 09-20-03" src="https://github.com/user-attachments/assets/2f9f0c02-75f6-4af8-afea-1106a073733c" />

### After PR:

<img width="750" height="455" alt="Знімок екрана з 2026-02-26 09-26-44" src="https://github.com/user-attachments/assets/7ab60ea0-a2c9-4644-a191-1d487aa95a72" />

### Executed Tests

None
