### PR TITLE
Add automated tests for Task Notifications #349

### DIFF
--- a/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/NotificationIT.java
+++ b/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/NotificationIT.java
@@ -361,28 +361,8 @@ class NotificationIT
         setup.createUser(NEW_ASSIGNEE, PASSWORD, "", "email", "newassignee@xwiki.org");
         logout(setup);
 
-        // Configure preferences.
-        doAsUser(setup, NEW_ASSIGNEE, () -> {
-            NotificationsUserProfilePage prefs = NotificationsUserProfilePage.gotoPage(NEW_ASSIGNEE);
-            prefs.disableAllParameters();
-
-            try {
-                ApplicationPreferences taskPrefs =
-                    prefs.getApplication(new TaskChangedEventDescriptor().getApplicationName());
-                setAlertState(setup, taskPrefs, BootstrapSwitch.State.ON);
-                setEmailState(setup, taskPrefs, BootstrapSwitch.State.ON);
-            } catch (Exception e) {
-                fail(e);
-            }
-        });
-
-        checkPreferences(setup, NEW_ASSIGNEE, BootstrapSwitch.State.ON);
-
-        // Clear notifications for new assignee.
-        doAsUser(setup, NEW_ASSIGNEE, () -> {
-            TaskManagerHomePage.gotoPage();
-            new NotificationsTrayPage().clearAllNotifications();
-        });
+        enableTaskNotifications(setup, NEW_ASSIGNEE);
+        clearNotifications(setup, NEW_ASSIGNEE);
 
         // Change assignee.
         doAsUser(setup, TEST_EDITOR_USERNAME, () -> {
@@ -393,21 +373,7 @@ class NotificationIT
         });
 
         // Verify new assignee is notified.
-        doAsUser(setup, NEW_ASSIGNEE, () -> {
-            TaskManagerHomePage.gotoPage();
-            NotificationsTrayPage.waitOnNotificationCount("xwiki:XWiki." + NEW_ASSIGNEE, "xwiki", 1);
-
-            NotificationsTrayPage tray = new NotificationsTrayPage();
-            tray.showNotificationTray();
-
-            assertEquals(1, tray.getNotificationsCount());
-            assertEquals(TaskChangedEvent.class.getName(), tray.getNotificationType(0));
-
-            List<String> details = getNotificationDetails(setup, 0);
-            assertEquals(1, details.size(), details.toString());
-        });
-
-        checkPreferences(setup, NEW_ASSIGNEE, BootstrapSwitch.State.ON);
+        checkTaskNotification(setup, NEW_ASSIGNEE);
     }
 
     /**
@@ -420,66 +386,22 @@ class NotificationIT
         final String USER1 = "rob";
         final String USER2 = "tod";
 
-        setup.createUser("rob", PASSWORD, "", "email", "rob@xwiki.org");
-        setup.createUser("tod", PASSWORD, "", "email", "tod@xwiki.org");
+        setup.createUser(USER1, PASSWORD, "", "email", "rob@xwiki.org");
+        setup.createUser(USER2, PASSWORD, "", "email", "tod@xwiki.org");
 
         // Enable notifications for both users.
         for (String user : List.of(USER1, USER2)) {
-            doAsUser(setup, user, () -> {
-                NotificationsUserProfilePage prefs = NotificationsUserProfilePage.gotoPage(user);
-                prefs.disableAllParameters();
-
-                try {
-                    ApplicationPreferences taskPrefs =
-                        prefs.getApplication(new TaskChangedEventDescriptor().getApplicationName());
-                    setAlertState(setup, taskPrefs, BootstrapSwitch.State.ON);
-                    setEmailState(setup, taskPrefs, BootstrapSwitch.State.ON);
-                } catch (Exception e) {
-                    fail(e);
-                }
-            });
-
-            checkPreferences(setup, user, BootstrapSwitch.State.ON);
-
-            // Clear notifications before test.
-            doAsUser(setup, user, () -> {
-                TaskManagerHomePage.gotoPage();
-                new NotificationsTrayPage().clearAllNotifications();
-            });
+            enableTaskNotifications(setup, user);
+            clearNotifications(setup, user);
         }
 
         doAsUser(setup, TEST_EDITOR_USERNAME, () -> {
             setup.createPage(MULTI_USER_TASK_PAGE, MULTI_USER_TASK, "Multi user task");
         });
 
-        // Verify USER1 gets notification.
-        doAsUser(setup, USER1, () -> {
-            TaskManagerHomePage.gotoPage();
-            NotificationsTrayPage.waitOnNotificationCount("xwiki:XWiki." + USER1, "xwiki", 1);
-
-            NotificationsTrayPage tray = new NotificationsTrayPage();
-            tray.showNotificationTray();
-
-            assertEquals(TaskChangedEvent.class.getName(), tray.getNotificationType(0));
-
-            List<String> details = getNotificationDetails(setup, 0);
-            assertEquals(1, details.size(), details.toString());
-        });
-
-        // Verify USER2 gets notification.
-        doAsUser(setup, USER2, () -> {
-            TaskManagerHomePage.gotoPage();
-            NotificationsTrayPage.waitOnNotificationCount("xwiki:XWiki." + USER2, "xwiki", 1);
-
-            NotificationsTrayPage tray = new NotificationsTrayPage();
-            tray.showNotificationTray();
-
-            assertEquals(TaskChangedEvent.class.getName(), tray.getNotificationType(0));
-
-            List<String> details = getNotificationDetails(setup, 0);
-            assertEquals(1, details.size(), details.toString());
-        });
-
+        // Verify both users get notifications.
+        checkTaskNotification(setup, USER1);
+        checkTaskNotification(setup, USER2);
     }
 
     /**
@@ -496,18 +418,10 @@ class NotificationIT
         logout(setup);
 
         // Enable task notifications.
+        enableTaskNotifications(setup, WATCHER);
+
         doAsUser(setup, WATCHER, () -> {
             NotificationsUserProfilePage prefs = NotificationsUserProfilePage.gotoPage(WATCHER);
-            prefs.disableAllParameters();
-
-            try {
-                ApplicationPreferences taskPrefs =
-                    prefs.getApplication(new TaskChangedEventDescriptor().getApplicationName());
-                setAlertState(setup, taskPrefs, BootstrapSwitch.State.ON);
-                setEmailState(setup, taskPrefs, BootstrapSwitch.State.ON);
-            } catch (Exception e) {
-                fail(e);
-            }
 
             // Disable system filters.
             for (SystemNotificationFilterPreference filter :
@@ -526,7 +440,6 @@ class NotificationIT
             bell.setPageOnly(true);
             assertTrue(bell.isPageOnlyEnabled());
         });
-        checkPreferences(setup, WATCHER, BootstrapSwitch.State.ON);
 
         // Trigger the notification.
         doAsUser(setup, TEST_EDITOR_USERNAME, () -> {
@@ -538,21 +451,7 @@ class NotificationIT
         });
 
         // Verify the user gets the notification.
-        doAsUser(setup, WATCHER, () -> {
-            TaskManagerHomePage.gotoPage();
-
-            NotificationsTrayPage.waitOnNotificationCount(
-                "xwiki:XWiki." + WATCHER,
-                "xwiki",
-                1
-            );
-
-            NotificationsTrayPage tray = new NotificationsTrayPage();
-            tray.showNotificationTray();
-
-            assertEquals(1, tray.getNotificationsCount());
-            assertEquals(TaskChangedEvent.class.getName(), tray.getNotificationType(0));
-        });
+        checkTaskNotification(setup, WATCHER);
     }
 
     private void setEmailState(TestUtils setup, ApplicationPreferences appPref, BootstrapSwitch.State alertState)
@@ -631,5 +530,49 @@ class NotificationIT
         setup.login(username, PASSWORD);
         action.run();
         logout(setup);
+    }
+
+    private void enableTaskNotifications(TestUtils setup, String user)
+    {
+        doAsUser(setup, user, () -> {
+            NotificationsUserProfilePage prefs = NotificationsUserProfilePage.gotoPage(user);
+            prefs.disableAllParameters();
+
+            try {
+                ApplicationPreferences taskPrefs =
+                    prefs.getApplication(new TaskChangedEventDescriptor().getApplicationName());
+                setAlertState(setup, taskPrefs, BootstrapSwitch.State.ON);
+                setEmailState(setup, taskPrefs, BootstrapSwitch.State.ON);
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+
+        checkPreferences(setup, user, BootstrapSwitch.State.ON);
+    }
+
+    private void clearNotifications(TestUtils setup, String user)
+    {
+        doAsUser(setup, user, () -> {
+            TaskManagerHomePage.gotoPage();
+            new NotificationsTrayPage().clearAllNotifications();
+        });
+    }
+
+    private void checkTaskNotification(TestUtils setup, String user)
+    {
+        doAsUser(setup, user, () -> {
+            TaskManagerHomePage.gotoPage();
+            NotificationsTrayPage.waitOnNotificationCount("xwiki:XWiki." + user, "xwiki", 1);
+
+            NotificationsTrayPage tray = new NotificationsTrayPage();
+            tray.showNotificationTray();
+
+            assertEquals(1, tray.getNotificationsCount());
+            assertEquals(TaskChangedEvent.class.getName(), tray.getNotificationType(0));
+
+            List<String> details = getNotificationDetails(setup, 0);
+            assertEquals(1, details.size(), details.toString());
+        });
     }
 }

--- a/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/NotificationIT.java
+++ b/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/NotificationIT.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.By;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
+import org.xwiki.contrib.application.task.test.po.NotificationButton;
 import org.xwiki.contrib.application.task.test.po.TaskAdminPage;
 import org.xwiki.contrib.application.task.test.po.TaskManagerHomePage;
 import org.xwiki.contrib.application.task.test.po.TaskManagerInlinePage;
@@ -39,6 +40,7 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.platform.notifications.test.po.NotificationsTrayPage;
 import org.xwiki.platform.notifications.test.po.NotificationsUserProfilePage;
 import org.xwiki.platform.notifications.test.po.preferences.ApplicationPreferences;
+import org.xwiki.platform.notifications.test.po.preferences.filters.SystemNotificationFilterPreference;
 import org.xwiki.scheduler.test.po.SchedulerHomePage;
 import org.xwiki.test.docker.junit5.ExtensionOverride;
 import org.xwiki.test.docker.junit5.TestConfiguration;
@@ -55,6 +57,7 @@ import com.xwiki.task.model.Task;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -124,6 +127,9 @@ class NotificationIT
         + "anchor=\"XWiki-afarcasi-v7dmha\"/}} {{mention reference=\"XWiki.tod\" style=\"FULL_NAME\" "
         + "anchor=\"XWiki-tcaras-mz6chz\"/}} \n {{/task}}";
 
+    private final DocumentReference MULTI_USER_TASK_PAGE =
+        new DocumentReference("xwiki", "Main", "MultiUserTaskPage");
+
     @BeforeAll
     void setup(TestUtils setup, TestConfiguration config) throws Exception
     {
@@ -166,6 +172,8 @@ class NotificationIT
         setup.loginAsSuperAdmin();
         setup.deletePage(new DocumentReference("xwiki", "TaskManager", TEST_TASK_NAME));
         setup.deletePage(TASK_MACRO_PAGE);
+        setup.deletePage(new DocumentReference("xwiki", "TaskManager", MULTI_USER_TASK));
+        setup.deletePage(MULTI_USER_TASK_PAGE);
         logout(setup);
     }
 
@@ -340,6 +348,9 @@ class NotificationIT
         checkPreferences(setup, TEST_USERNAME, BootstrapSwitch.State.OFF);
     }
 
+    /**
+     * Test that changing a task assignee triggers a notification to the new assignee.
+     */
     @Test
     @Order(6)
     void assigneeChangeNotification(TestUtils setup)
@@ -355,14 +366,9 @@ class NotificationIT
             NotificationsUserProfilePage prefs = NotificationsUserProfilePage.gotoPage(NEW_ASSIGNEE);
             prefs.disableAllParameters();
 
-            ApplicationPreferences taskPrefs =
-                null;
             try {
-                taskPrefs = prefs.getApplication(new TaskChangedEventDescriptor().getApplicationName());
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            try {
+                ApplicationPreferences taskPrefs =
+                    prefs.getApplication(new TaskChangedEventDescriptor().getApplicationName());
                 setAlertState(setup, taskPrefs, BootstrapSwitch.State.ON);
                 setEmailState(setup, taskPrefs, BootstrapSwitch.State.ON);
             } catch (Exception e) {
@@ -386,7 +392,7 @@ class NotificationIT
             inlinePage.clickSaveAndView();
         });
 
-        // Verify new assignee notified.
+        // Verify new assignee is notified.
         doAsUser(setup, NEW_ASSIGNEE, () -> {
             TaskManagerHomePage.gotoPage();
             NotificationsTrayPage.waitOnNotificationCount("xwiki:XWiki." + NEW_ASSIGNEE, "xwiki", 1);
@@ -404,12 +410,18 @@ class NotificationIT
         checkPreferences(setup, NEW_ASSIGNEE, BootstrapSwitch.State.ON);
     }
 
+    /**
+     * Test that all users assigned to a task receive a notification.
+     */
     @Test
     @Order(7)
-    void multiUserTaskNotification(TestUtils setup)
+    void multipleAssigneesNotification(TestUtils setup)
     {
         final String USER1 = "rob";
         final String USER2 = "tod";
+
+        setup.createUser("rob", PASSWORD, "", "email", "rob@xwiki.org");
+        setup.createUser("tod", PASSWORD, "", "email", "tod@xwiki.org");
 
         // Enable notifications for both users.
         for (String user : List.of(USER1, USER2)) {
@@ -436,12 +448,8 @@ class NotificationIT
             });
         }
 
-        // Create page with multi-user task.
-        DocumentReference multiUserPage =
-            new DocumentReference("xwiki", "Main", "MultiUserTaskPage");
-
         doAsUser(setup, TEST_EDITOR_USERNAME, () -> {
-            setup.createPage(multiUserPage, MULTI_USER_TASK, "Multi user task");
+            setup.createPage(MULTI_USER_TASK_PAGE, MULTI_USER_TASK, "Multi user task");
         });
 
         // Verify USER1 gets notification.
@@ -472,6 +480,79 @@ class NotificationIT
             assertEquals(1, details.size(), details.toString());
         });
 
+    }
+
+    /**
+     * Test that a watcher receives notifications for task updates when page-level watching is enabled.
+     */
+    @Test
+    @Order(8)
+    void watcherReceivesNotification(TestUtils setup) throws Exception
+    {
+        final String WATCHER = "TaskWatcher";
+
+        setup.loginAsSuperAdmin();
+        setup.createUser(WATCHER, PASSWORD, "", "email", "watcher@xwiki.org");
+        logout(setup);
+
+        // Enable task notifications.
+        doAsUser(setup, WATCHER, () -> {
+            NotificationsUserProfilePage prefs = NotificationsUserProfilePage.gotoPage(WATCHER);
+            prefs.disableAllParameters();
+
+            try {
+                ApplicationPreferences taskPrefs =
+                    prefs.getApplication(new TaskChangedEventDescriptor().getApplicationName());
+                setAlertState(setup, taskPrefs, BootstrapSwitch.State.ON);
+                setEmailState(setup, taskPrefs, BootstrapSwitch.State.ON);
+            } catch (Exception e) {
+                fail(e);
+            }
+
+            // Disable system filters.
+            for (SystemNotificationFilterPreference filter :
+                prefs.getSystemNotificationFilterPreferences()) {
+                try {
+                    filter.setEnabled(false);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            // Go to the task page and enable the notifications for it.
+            setup.gotoPage("TaskManager", TEST_TASK_NAME);
+            NotificationButton bell = new NotificationButton();
+            bell.open();
+            bell.setPageOnly(true);
+            assertTrue(bell.isPageOnlyEnabled());
+        });
+        checkPreferences(setup, WATCHER, BootstrapSwitch.State.ON);
+
+        // Trigger the notification.
+        doAsUser(setup, TEST_EDITOR_USERNAME, () -> {
+            setup.gotoPage("TaskManager", TEST_TASK_NAME, "edit");
+
+            TaskManagerInlinePage inlinePage = new TaskManagerInlinePage();
+            inlinePage.setStatus(Task.STATUS_IN_PROGRESS);
+            inlinePage.clickSaveAndView();
+        });
+
+        // Verify the user gets the notification.
+        doAsUser(setup, WATCHER, () -> {
+            TaskManagerHomePage.gotoPage();
+
+            NotificationsTrayPage.waitOnNotificationCount(
+                "xwiki:XWiki." + WATCHER,
+                "xwiki",
+                1
+            );
+
+            NotificationsTrayPage tray = new NotificationsTrayPage();
+            tray.showNotificationTray();
+
+            assertEquals(1, tray.getNotificationsCount());
+            assertEquals(TaskChangedEvent.class.getName(), tray.getNotificationType(0));
+        });
     }
 
     private void setEmailState(TestUtils setup, ApplicationPreferences appPref, BootstrapSwitch.State alertState)

--- a/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/NotificationIT.java
+++ b/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/NotificationIT.java
@@ -119,6 +119,11 @@ class NotificationIT
 
     private final String TEST_PROJECT_NAME = "Test Project";
 
+    private static final String MULTI_USER_TASK = "{{task reference=\"Task_4\" createDate=\"2025/04/28 14:51\" "
+        + "reporter=\"XWiki.afarcasi\"}}\n {{mention reference=\"XWiki.rob\" style=\"FULL_NAME\" "
+        + "anchor=\"XWiki-afarcasi-v7dmha\"/}} {{mention reference=\"XWiki.tod\" style=\"FULL_NAME\" "
+        + "anchor=\"XWiki-tcaras-mz6chz\"/}} \n {{/task}}";
+
     @BeforeAll
     void setup(TestUtils setup, TestConfiguration config) throws Exception
     {
@@ -333,6 +338,140 @@ class NotificationIT
                 () -> NotificationsTrayPage.waitOnNotificationCount("xwiki:XWiki." + TEST_USERNAME, "xwiki", 1));
         });
         checkPreferences(setup, TEST_USERNAME, BootstrapSwitch.State.OFF);
+    }
+
+    @Test
+    @Order(6)
+    void assigneeChangeNotification(TestUtils setup)
+    {
+        final String NEW_ASSIGNEE = "NotificationNewAssignee";
+
+        setup.loginAsSuperAdmin();
+        setup.createUser(NEW_ASSIGNEE, PASSWORD, "", "email", "newassignee@xwiki.org");
+        logout(setup);
+
+        // Configure preferences.
+        doAsUser(setup, NEW_ASSIGNEE, () -> {
+            NotificationsUserProfilePage prefs = NotificationsUserProfilePage.gotoPage(NEW_ASSIGNEE);
+            prefs.disableAllParameters();
+
+            ApplicationPreferences taskPrefs =
+                null;
+            try {
+                taskPrefs = prefs.getApplication(new TaskChangedEventDescriptor().getApplicationName());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            try {
+                setAlertState(setup, taskPrefs, BootstrapSwitch.State.ON);
+                setEmailState(setup, taskPrefs, BootstrapSwitch.State.ON);
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+
+        checkPreferences(setup, NEW_ASSIGNEE, BootstrapSwitch.State.ON);
+
+        // Clear notifications for new assignee.
+        doAsUser(setup, NEW_ASSIGNEE, () -> {
+            TaskManagerHomePage.gotoPage();
+            new NotificationsTrayPage().clearAllNotifications();
+        });
+
+        // Change assignee.
+        doAsUser(setup, TEST_EDITOR_USERNAME, () -> {
+            setup.gotoPage("TaskManager", TEST_TASK_NAME, "edit");
+            TaskManagerInlinePage inlinePage = new TaskManagerInlinePage();
+            inlinePage.setAssignee("XWiki." + NEW_ASSIGNEE);
+            inlinePage.clickSaveAndView();
+        });
+
+        // Verify new assignee notified.
+        doAsUser(setup, NEW_ASSIGNEE, () -> {
+            TaskManagerHomePage.gotoPage();
+            NotificationsTrayPage.waitOnNotificationCount("xwiki:XWiki." + NEW_ASSIGNEE, "xwiki", 1);
+
+            NotificationsTrayPage tray = new NotificationsTrayPage();
+            tray.showNotificationTray();
+
+            assertEquals(1, tray.getNotificationsCount());
+            assertEquals(TaskChangedEvent.class.getName(), tray.getNotificationType(0));
+
+            List<String> details = getNotificationDetails(setup, 0);
+            assertEquals(1, details.size(), details.toString());
+        });
+
+        checkPreferences(setup, NEW_ASSIGNEE, BootstrapSwitch.State.ON);
+    }
+
+    @Test
+    @Order(7)
+    void multiUserTaskNotification(TestUtils setup)
+    {
+        final String USER1 = "rob";
+        final String USER2 = "tod";
+
+        // Enable notifications for both users.
+        for (String user : List.of(USER1, USER2)) {
+            doAsUser(setup, user, () -> {
+                NotificationsUserProfilePage prefs = NotificationsUserProfilePage.gotoPage(user);
+                prefs.disableAllParameters();
+
+                try {
+                    ApplicationPreferences taskPrefs =
+                        prefs.getApplication(new TaskChangedEventDescriptor().getApplicationName());
+                    setAlertState(setup, taskPrefs, BootstrapSwitch.State.ON);
+                    setEmailState(setup, taskPrefs, BootstrapSwitch.State.ON);
+                } catch (Exception e) {
+                    fail(e);
+                }
+            });
+
+            checkPreferences(setup, user, BootstrapSwitch.State.ON);
+
+            // Clear notifications before test.
+            doAsUser(setup, user, () -> {
+                TaskManagerHomePage.gotoPage();
+                new NotificationsTrayPage().clearAllNotifications();
+            });
+        }
+
+        // Create page with multi-user task.
+        DocumentReference multiUserPage =
+            new DocumentReference("xwiki", "Main", "MultiUserTaskPage");
+
+        doAsUser(setup, TEST_EDITOR_USERNAME, () -> {
+            setup.createPage(multiUserPage, MULTI_USER_TASK, "Multi user task");
+        });
+
+        // Verify USER1 gets notification.
+        doAsUser(setup, USER1, () -> {
+            TaskManagerHomePage.gotoPage();
+            NotificationsTrayPage.waitOnNotificationCount("xwiki:XWiki." + USER1, "xwiki", 1);
+
+            NotificationsTrayPage tray = new NotificationsTrayPage();
+            tray.showNotificationTray();
+
+            assertEquals(TaskChangedEvent.class.getName(), tray.getNotificationType(0));
+
+            List<String> details = getNotificationDetails(setup, 0);
+            assertEquals(1, details.size(), details.toString());
+        });
+
+        // Verify USER2 gets notification.
+        doAsUser(setup, USER2, () -> {
+            TaskManagerHomePage.gotoPage();
+            NotificationsTrayPage.waitOnNotificationCount("xwiki:XWiki." + USER2, "xwiki", 1);
+
+            NotificationsTrayPage tray = new NotificationsTrayPage();
+            tray.showNotificationTray();
+
+            assertEquals(TaskChangedEvent.class.getName(), tray.getNotificationType(0));
+
+            List<String> details = getNotificationDetails(setup, 0);
+            assertEquals(1, details.size(), details.toString());
+        });
+
     }
 
     private void setEmailState(TestUtils setup, ApplicationPreferences appPref, BootstrapSwitch.State alertState)

--- a/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
+++ b/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
@@ -102,14 +102,6 @@ class TaskManagerIT
 
     private static final String USER_NAME = "BOB";
 
-    private static final String specialCharactersTask =
-        "{{task reference=\"TTe$t with #special + ch@rs - test. It's ^a test! Test ~1 = and (2) & {3}, [4]."
-            + " 100% a test 1; 2` 3; 5\"}}TTe$t with #special + ch@rs - test. It's ^a test! Test ~1 = and (2) & {3}, [4]."
-            + " 100% a test 1; 2` 3; 5{{/task}}\n";
-
-    private final LocalDocumentReference pageWithSpecialCharactersTask =
-        new LocalDocumentReference("Main", "SpecialCharactersTest");
-
     @BeforeAll
     void setup(TestUtils setup)
     {
@@ -458,23 +450,5 @@ class TaskManagerIT
         for (int i = 0; i < ids.size(); i++) {
             assertEquals(expectedResults.get(i), taskAdminPage.countSectionElements(ids.get(i)));
         }
-    }
-
-    @ParameterizedTest
-    @WikisSource()
-    @Order(120)
-    void specialCharactersTaskNameAndContent(WikiReference wiki, TestUtils setup) throws Exception
-    {
-        setup.setCurrentWiki(wiki.getName());
-        DocumentReference testRef = new DocumentReference(pageWithSpecialCharactersTask, wiki);
-        setup.createPage(testRef, specialCharactersTask);
-
-        ViewPageWithTasks viewPage = new ViewPageWithTasks();
-        assertEquals(1, viewPage.getTaskMacros().size());
-
-        assertEquals("TTe$t with #special + ch@rs - test. It's ^a test! Test 1 = and (2) & {3}, [4]. 100% a test 1; "
-            + "2` 3; 5", viewPage.getTaskMacroContent(0));
-
-        setup.deletePage(pageWithSpecialCharactersTask);
     }
 }

--- a/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
+++ b/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
@@ -102,6 +102,14 @@ class TaskManagerIT
 
     private static final String USER_NAME = "BOB";
 
+    private static final String specialCharactersTask =
+        "{{task reference=\"TTe$t with #special + ch@rs - test. It's ^a test! Test ~1 = and (2) & {3}, [4]."
+            + " 100% a test 1; 2` 3; 5\"}}TTe$t with #special + ch@rs - test. It's ^a test! Test ~1 = and (2) & {3}, [4]."
+            + " 100% a test 1; 2` 3; 5{{/task}}\n";
+
+    private final LocalDocumentReference pageWithSpecialCharactersTask =
+        new LocalDocumentReference("Main", "SpecialCharactersTest");
+
     @BeforeAll
     void setup(TestUtils setup)
     {
@@ -450,5 +458,21 @@ class TaskManagerIT
         for (int i = 0; i < ids.size(); i++) {
             assertEquals(expectedResults.get(i), taskAdminPage.countSectionElements(ids.get(i)));
         }
+    }
+
+    @ParameterizedTest
+    @WikisSource()
+    @Order(120)
+    void specialCharactersTaskNameAndContent(WikiReference wiki, TestUtils setup) throws Exception
+    {
+        setup.setCurrentWiki(wiki.getName());
+        DocumentReference testRef = new DocumentReference(pageWithSpecialCharactersTask, wiki);
+        setup.createPage(testRef, specialCharactersTask);
+
+        ViewPageWithTasks viewPage = new ViewPageWithTasks();
+        assertEquals(1, viewPage.getTaskMacros().size());
+
+        assertEquals("TTe$t with #special + ch@rs - test. It's ^a test! Test 1 = and (2) & {3}, [4]. 100% a test 1; "
+            + "2` 3; 5", viewPage.getTaskMacroContent(0));
     }
 }

--- a/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
+++ b/application-task-test/application-task-test-docker/src/test/it/com/xwiki/task/test/ui/TaskManagerIT.java
@@ -474,5 +474,7 @@ class TaskManagerIT
 
         assertEquals("TTe$t with #special + ch@rs - test. It's ^a test! Test 1 = and (2) & {3}, [4]. 100% a test 1; "
             + "2` 3; 5", viewPage.getTaskMacroContent(0));
+
+        setup.deletePage(pageWithSpecialCharactersTask);
     }
 }

--- a/application-task-test/application-task-test-pageobjects/src/main/java/org/xwiki/contrib/application/task/test/po/NotificationButton.java
+++ b/application-task-test/application-task-test-pageobjects/src/main/java/org/xwiki/contrib/application/task/test/po/NotificationButton.java
@@ -1,0 +1,114 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.xwiki.contrib.application.task.test.po;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.xwiki.test.ui.po.BaseElement;
+
+/**
+ * Represents the Notification menu and provides access to its settings.
+ *
+ * @version $Id$
+ * @since 3.11.0
+ */
+public class NotificationButton extends BaseElement
+{
+    private static final By PAGE_ONLY = By.id("notificationPageOnly");
+
+    private static final By PAGE_AND_CHILDREN = By.id("notificationPageAndChildren");
+
+    private static final By WIKI = By.id("notificationWiki");
+
+    @FindBy(css = "#tmNotifications button.dropdown-toggle")
+    private WebElement button;
+
+    public NotificationButton open()
+    {
+
+        button.click();
+
+        By dropdown = By.cssSelector("#tmNotifications .dropdown-menu");
+        getDriver().waitUntilElementIsVisible(dropdown);
+
+        getDriver().waitUntilCondition(
+            d -> d.findElement(dropdown).getAttribute("class").contains("open") || d.findElement(dropdown)
+                .isDisplayed(), 5);
+
+        return this;
+    }
+
+    public NotificationButton setWiki(boolean value)
+    {
+        setCheckbox(WIKI, value);
+        return this;
+    }
+
+    public NotificationButton setPageOnly(boolean value)
+    {
+        setCheckbox(PAGE_ONLY, value);
+        return this;
+    }
+
+    public NotificationButton setPageAndChildren(boolean value)
+    {
+        setCheckbox(PAGE_AND_CHILDREN, value);
+        return this;
+    }
+
+    public boolean isPageOnlyEnabled()
+    {
+        return getDriver().findElement(PAGE_ONLY).isSelected();
+    }
+
+    public boolean isPageAndChildrenEnabled()
+    {
+        return getDriver().findElement(PAGE_AND_CHILDREN).isSelected();
+    }
+
+    public boolean isWikiEnabled()
+    {
+        return getDriver().findElement(WIKI).isSelected();
+    }
+
+    private void setCheckbox(By locator, boolean value)
+    {
+        WebElement input = getDriver().findElement(locator);
+
+        String id = input.getAttribute("id");
+
+        By switchLocator = By.cssSelector(".bootstrap-switch-id-" + id);
+
+        WebElement toggle = getDriver().findElement(switchLocator);
+
+        getDriver().waitUntilCondition(d -> toggle.isDisplayed(), 10);
+
+        boolean isOn = toggle.getAttribute("class").contains("bootstrap-switch-on");
+
+        if (isOn != value) {
+            toggle.click();
+
+            getDriver().waitUntilCondition(d -> getDriver().findElement(switchLocator).getAttribute("class")
+                .contains(value ? "bootstrap-switch-on" : "bootstrap-switch-off"), 5);
+        }
+    }
+}


### PR DESCRIPTION
Added automated tests for Task Notifications for the following use cases:

-     when the assignee is changed
-     when multiple users are assigned - this test fails (the fix has not been merged yet)
-     by manually watching a task (by creating a notification filter for the task page), a user can receive notifications for tasks they are not assigned to. 

fixes #349 
