### PR TITLE
Deleted Task Manager Status Appears as Localization Key in Task Card Macro #365

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/TaskCardMacro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskCardMacro.xml
@@ -559,9 +559,9 @@
 ##
 ## Display the status of the task
 #macro(displayCardStatus $taskstatus)
-  #if(!$taskstatus.trim().isEmpty())
-    #set($key = "TaskManager.TaskManagerClass_status_$taskstatus")
-    #set($translation = $services.localization.render($key))
+  #if (!$taskstatus.trim().isEmpty())
+    #set ($key = "TaskManager.TaskManagerClass_status_$taskstatus")
+    #set ($translation = $services.localization.render($key))
     #if ($translation == $key)
       #set ($renderedStatus = $services.rendering.escape($taskstatus, 'xwiki/2.1'))
     #else

--- a/application-task-ui/src/main/resources/TaskManager/TaskCardMacro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/TaskCardMacro.xml
@@ -560,10 +560,17 @@
 ## Display the status of the task
 #macro(displayCardStatus $taskstatus)
   #if(!$taskstatus.trim().isEmpty())
-  (% class="col-xs-12 task-card-status" %)
-  (((
-    ${services.icon.render('bell')} [$services.localization.render("TaskManager.TaskManagerClass_status_${taskstatus}")]
-  )))
+    #set($key = "TaskManager.TaskManagerClass_status_$taskstatus")
+    #set($translation = $services.localization.render($key))
+    #if ($translation == $key)
+      #set ($renderedStatus = $services.rendering.escape($taskstatus, 'xwiki/2.1'))
+    #else
+      #set ($renderedStatus = $services.rendering.escape($translation, 'xwiki/2.1'))
+    #end
+    (% class="col-xs-12 task-card-status" %)
+    (((
+      ${services.icon.render('bell')} [$renderedStatus]
+    )))
   #end
 #end
 #### MACRO displayCardTitle


### PR DESCRIPTION
Updated the task status rendering so it is like the other pages.

A better solution would be to pull out this logic in a separate page and reuse it where necessary