### PR TITLE
Gantt Diagram Macro Does Not Load Tasks When "Read Only" Is Enabled #369

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/GanttMacro/Macro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/GanttMacro/Macro.xml
@@ -1133,7 +1133,10 @@ define('taskgantt-frappe', ['taskgantt-frappe-methods', 'frappe-gantt'], functio
 
     return gantt;
   };
-  Promise.all($.map($('.taskgantt'), spawnGantt));
+  // Listener so the tasks are displayed when stepping out of WYSIWYG. Otherwise the tasks would be removed.
+  document.on('xwiki:dom:updated', () =&gt; {
+    Promise.all($.map($('.taskgantt'), spawnGantt));
+  });
 });</code>
     </property>
     <property>

--- a/application-task-ui/src/main/resources/TaskManager/GanttMacro/Macro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/GanttMacro/Macro.xml
@@ -1141,6 +1141,7 @@ define('taskgantt-frappe', ['taskgantt-frappe-methods', 'frappe-gantt'], functio
   document.on('xwiki:dom:updated', () =&gt; {
     Promise.all($.map($('.taskgantt'), spawnGantt));
   });
+  Promise.all($.map($('.taskgantt'), spawnGantt));
 });</code>
     </property>
     <property>

--- a/application-task-ui/src/main/resources/TaskManager/GanttMacro/Macro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/GanttMacro/Macro.xml
@@ -1095,9 +1095,13 @@ define('taskgantt-frappe', ['taskgantt-frappe-methods', 'frappe-gantt'], functio
     let tasks = await fetch(serviceUrls.getJsonSourceURL(ganttDiv)).then(response =&gt; response.json());
     if (tasks.length == 0) {
       // Frappe breaks if it has no tasks to display, so replace it with an error message.
-      $(ganttDiv).append(tgtemplates.noTasksMessage);
-      $(ganttDiv).find('#view-mode-buttons').empty();
+      if (!$(ganttDiv).find('#ganttNoTasksMessage').length) {
+        $(ganttDiv).append(tgtemplates.noTasksMessage);
+      }
+      $(ganttDiv).find('#view-mode-buttons').toggleClass('hidden', true);
       return;
+    } else {
+      $(ganttDiv).find('#view-mode-buttons').toggleClass('hidden', false);
     }
     tasks.forEach(taskutil.formatTask);
     tasks.forEach((task) =&gt; {
@@ -1831,7 +1835,7 @@ path=$services.webjars.url('org.webjars.npm:frappe-gantt', "dist/frappe-gantt.mi
   &lt;button type="button" class='btn view-mode-button' value="$viewMode"&gt;$escapetool.html($text)&lt;/button&gt;
 #end
 #macro (noTasksMessage)
-  &lt;div class='box'&gt;$escapetool.html($services.localization.render('taskmanager.gantt.macro.noTasks'))&lt;/div&gt;
+  &lt;div class='box' id='ganttNoTasksMessage'&gt;$escapetool.xml($services.localization.render('taskmanager.gantt.macro.noTasks'))&lt;/div&gt;
 #end
 #macro (svgCustomDefs)
   &lt;linearGradient id="fadeGrad"&gt;
@@ -1880,8 +1884,9 @@ path=$services.webjars.url('org.webjars.npm:frappe-gantt', "dist/frappe-gantt.mi
   #set ($discard = $config.put('svgCustomDefs', "#svgCustomDefs"))
   #set ($discard = $config.put('noTasksMessage', "#noTasksMessage"))
   {{html clean='false'}}
-  &lt;script id='taskgantt-config-templates' type='application/json'&gt;$jsontool.serialize($config).replace('&amp;lt;', '\u003C')
-  &lt;/script&gt;
+  &lt;div class='hidden' id='taskgantt-config-templates' type='application/json'&gt;
+    $escapetool.xml($jsontool.serialize($config))
+  &lt;/div&gt;
   {{/html}}
 
 {{html}}


### PR DESCRIPTION
The issue is caused by transitioning from the WYSIWYG editor to view mode:

The gantt javascript code loads the tasks for the current view (WYSIWYG). When switching to view mode, the page content is reset, and the gantt javascript is not run again, causing the tasks to disappear when viewing the page.

Refreshing the page worked fine, since the content isn't being deleted by WYSIWYG after the gantt javascript runs.

To fix this, I added a retrigger for the gantt javascript on `xwiki:dom:updated` event, and switched a script tag which was holding some JSON information to a div (since WYSIWYG seems to remove script tags in macro content, which was causing some issues).