### PR TITLE
Gantt chart opens on the first task date instead of the current date #368

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/GanttMacro/Macro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/GanttMacro/Macro.xml
@@ -1131,6 +1131,14 @@ define('taskgantt-frappe', ['taskgantt-frappe-methods', 'frappe-gantt'], functio
       gantt.change_view_mode(e.currentTarget.value);
     });
 
+    // Scroll to today (if available)
+    const scrolledGanttDiv = ganttDiv.querySelector('svg.gantt').parentNode;
+    const todayMarker = scrolledGanttDiv?.querySelector('.today-highlight');
+    if (todayMarker) {
+      const markerX = Number.parseFloat(todayMarker.getAttribute('x'));
+      scrolledGanttDiv.scrollLeft = markerX - scrolledGanttDiv.getBoundingClientRect().width / 2;
+    }
+
     return gantt;
   };
   Promise.all($.map($('.taskgantt'), spawnGantt));

--- a/application-task-ui/src/main/resources/TaskManager/GanttMacro/Macro.xml
+++ b/application-task-ui/src/main/resources/TaskManager/GanttMacro/Macro.xml
@@ -1088,6 +1088,16 @@ define('taskgantt-frappe', ['taskgantt-frappe-methods', 'frappe-gantt'], functio
   'frappe-gantt',
   'taskgantt-frappe'
 ], function ($, serviceUrls, l10n, overrideDefs, taskutil, tgtemplates) {
+  function scrollToToday(ganttDiv) {
+    // Scroll to today (if available)
+    const scrolledGanttDiv = ganttDiv.querySelector('svg.gantt').parentNode;
+    const todayMarker = scrolledGanttDiv?.querySelector('.today-highlight');
+    const markerX = Number.parseFloat(todayMarker?.getAttribute('x'));
+    if (todayMarker &amp;&amp; markerX &lt; Number.parseFloat(ganttDiv.querySelector('svg.gantt').getAttribute('width'))) {
+      scrolledGanttDiv.scrollLeft = markerX - scrolledGanttDiv.getBoundingClientRect().width / 2;
+    }
+  }
+
   async function spawnGantt(ganttDiv, idx) {
 
     $(ganttDiv).attr('id', 'taskgantt-gantt' + idx);
@@ -1129,15 +1139,10 @@ define('taskgantt-frappe', ['taskgantt-frappe-methods', 'frappe-gantt'], functio
     // Bind viewmode buttons.
     $('#view-mode-buttons &gt; button.view-mode-button', ganttDiv).on('click', (e) =&gt; {
       gantt.change_view_mode(e.currentTarget.value);
+      scrollToToday(ganttDiv);
     });
 
-    // Scroll to today (if available)
-    const scrolledGanttDiv = ganttDiv.querySelector('svg.gantt').parentNode;
-    const todayMarker = scrolledGanttDiv?.querySelector('.today-highlight');
-    if (todayMarker) {
-      const markerX = Number.parseFloat(todayMarker.getAttribute('x'));
-      scrolledGanttDiv.scrollLeft = markerX - scrolledGanttDiv.getBoundingClientRect().width / 2;
-    }
+    scrollToToday(ganttDiv);
 
     return gantt;
   };


### PR DESCRIPTION
Added additional step to scroll to current day, if it exists. Only applied to day mode view (so year/quarter day/ etc views are not affected by this improvement)

Upgrading frappe/gantt to a newer version could take care of this implicitly.