### PR TITLE
Gantt Macro doesn't display inline tasks #393

### DIFF
--- a/application-task-ui/src/main/resources/TaskManager/GanttMacro/JSONTaskSource.xml
+++ b/application-task-ui/src/main/resources/TaskManager/GanttMacro/JSONTaskSource.xml
@@ -154,7 +154,7 @@
     #if ($from)      #set ($query = $query.bindValue('from', $from))           #end
     #if ($to)        #set ($query = $query.bindValue('to', $to))               #end
   #end
-  #set ($queryResult = $query.addFilter('hidden').addFilter('currentlanguage').execute())
+  #set ($queryResult = $query.addFilter('currentlanguage').execute())
 
   #set ($tasks = [])
   #foreach ($taskDocument in $queryResult)


### PR DESCRIPTION
Removed the `hidden` sql filter which was causing the issue. Now the gantt macro should be more in line with the behavior of other task macros.